### PR TITLE
Add Enter key support for API checking

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -6,7 +6,7 @@
 
 <div class="mb-3">
     <label for="wpUrl" class="form-label">WordPress site URL</label>
-    <input id="wpUrl" class="form-control" @bind="userUrl" placeholder="https://example.com" />
+    <input id="wpUrl" class="form-control" @bind="userUrl" @onkeydown="HandleKeyDown" placeholder="https://example.com" />
 </div>
 <button class="btn btn-primary" @onclick="CheckApi">Check API</button>
 
@@ -101,6 +101,14 @@
         if (string.IsNullOrEmpty(status))
         {
             status = "Failed to verify endpoint.";
+        }
+    }
+
+    private async Task HandleKeyDown(KeyboardEventArgs e)
+    {
+        if (e.Key == "Enter")
+        {
+            await CheckApi();
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow Enter key on input to trigger API check

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c036a4f08322ba85aef3b69b8a47