### PR TITLE
Add code box for communication log

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -19,12 +19,7 @@
 {
     <div class="mt-3">
         <h5>Communication Log</h5>
-        <ul>
-            @foreach (var entry in logs)
-            {
-                <li>@entry</li>
-            }
-        </ul>
+        <pre class="log-box">@string.Join("\n", logs)</pre>
     </div>
 }
 
@@ -60,7 +55,6 @@
     private async Task CheckApi()
     {
         status = null;
-        logs.Clear();
 
         if (string.IsNullOrWhiteSpace(userUrl))
         {

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -112,3 +112,14 @@ code {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+.log-box {
+    background-color: #000;
+    color: #0f0;
+    padding: 1rem;
+    border-radius: 4px;
+    font-family: monospace;
+    white-space: pre-line;
+    max-height: 300px;
+    overflow-y: auto;
+}
+


### PR DESCRIPTION
## Summary
- display communication log inside a `<pre>`
- keep history between checks
- style log box with black background using new `.log-box` CSS class

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850c2fa28f88322b1f0c4183863b1dc