### PR TITLE
Add raw HTTP byte logging

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -97,8 +97,15 @@
                 await InvokeAsync(StateHasChanged);
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                var response = await Http.GetAsync(endpoint, cts.Token);
-                logs.Add($"Status {(int)response.StatusCode}");
+                var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+                logs.Add($"-> {request}");
+                await InvokeAsync(StateHasChanged);
+
+                var response = await Http.SendAsync(request, cts.Token);
+                logs.Add($"<- {response}");
+                var bytes = await response.Content.ReadAsByteArrayAsync();
+                var hex = BitConverter.ToString(bytes.Take(256).ToArray());
+                logs.Add($"<- Body: {hex}");
                 await InvokeAsync(StateHasChanged);
                 if (response.IsSuccessStatusCode)
                 {

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -9,3 +9,5 @@
 @using Microsoft.JSInterop
 @using BlazorWP
 @using BlazorWP.Layout
+@using System.Linq
+@using System.Text


### PR DESCRIPTION
## Summary
- log request and response objects and first 256 bytes of the body
- add `System.Linq` and `System.Text` usings

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6850c410cb248322acd0f0e57346ce23