### PR TITLE
Improve HTTP response logging

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -102,10 +102,8 @@
                 await InvokeAsync(StateHasChanged);
 
                 var response = await Http.SendAsync(request, cts.Token);
-                logs.Add($"<- {response}");
-                var bytes = await response.Content.ReadAsByteArrayAsync();
-                var hex = BitConverter.ToString(bytes.Take(256).ToArray());
-                logs.Add($"<- Body: {hex}");
+                var raw = await FormatRawResponse(response);
+                logs.Add($"<- {raw}");
                 await InvokeAsync(StateHasChanged);
                 if (response.IsSuccessStatusCode)
                 {
@@ -135,5 +133,39 @@
         {
             await CheckApi();
         }
+    }
+
+    private static async Task<string> FormatRawResponse(HttpResponseMessage response)
+    {
+        var sb = new StringBuilder();
+        sb.Append($"HTTP/{response.Version.Major}.{response.Version.Minor} {(int)response.StatusCode} {response.ReasonPhrase}\r\n");
+        foreach (var header in response.Headers)
+        {
+            sb.Append($"{header.Key}: {string.Join(", ", header.Value)}\r\n");
+        }
+        foreach (var header in response.Content.Headers)
+        {
+            sb.Append($"{header.Key}: {string.Join(", ", header.Value)}\r\n");
+        }
+        sb.Append("\r\n");
+        var bytes = await response.Content.ReadAsByteArrayAsync();
+        Encoding encoding;
+        if (response.Content.Headers.ContentType?.CharSet is string cs)
+        {
+            try
+            {
+                encoding = Encoding.GetEncoding(cs);
+            }
+            catch
+            {
+                encoding = Encoding.UTF8;
+            }
+        }
+        else
+        {
+            encoding = Encoding.UTF8;
+        }
+        sb.Append(encoding.GetString(bytes));
+        return sb.ToString();
     }
 }


### PR DESCRIPTION
## Summary
- log raw HTTP responses for easier inspection
- add helper method to format headers and body with CRLF separation

## Testing
- `dotnet build BlazorWP.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6850c65d0b6083228fcbf4fbdb52adb0