### PR TITLE
Add WordPress API viewer

### DIFF
--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -24,6 +24,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Weather
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="api">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> API
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/ApiViewer.razor
+++ b/Pages/ApiViewer.razor
@@ -1,0 +1,61 @@
+@page "/api"
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+<PageTitle>API Viewer</PageTitle>
+
+<h1>WordPress API Viewer</h1>
+
+@if (loading)
+{
+    <p><em>Loading...</em></p>
+}
+else if (error != null)
+{
+    <p class="text-danger">@error</p>
+}
+else if (formattedJson != null)
+{
+    <pre class="json-view">@formattedJson</pre>
+}
+else
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+
+@code {
+    private string? formattedJson;
+    private string? error;
+    private bool loading = true;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            loading = false;
+            return;
+        }
+
+        var rootEndpoint = endpoint;
+        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
+        {
+            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
+        }
+
+        try
+        {
+            var json = await Http.GetStringAsync(rootEndpoint);
+            using var doc = JsonDocument.Parse(json);
+            formattedJson = JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+}

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -11,3 +11,4 @@
 @using BlazorWP.Layout
 @using System.Linq
 @using System.Text
+@using System.Text.Json

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -123,3 +123,11 @@ code {
     overflow-y: auto;
 }
 
+.json-view {
+    background-color: #f8f9fa;
+    padding: 1rem;
+    border-radius: 4px;
+    font-family: monospace;
+    white-space: pre;
+    overflow-x: auto;
+}


### PR DESCRIPTION
## Summary
- add `/api` page that loads the WordPress API root from the saved endpoint and pretty prints the JSON
- add navigation link to the new page
- style the JSON output

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6850f91697148322afb581d3d651fe0e