### PR TITLE
Add missing MudPopoverProvider

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -1,4 +1,7 @@
-﻿@inherits LayoutComponentBase
+@inherits LayoutComponentBase
+
+<MudPopoverProvider />
+
 <div class="page">
     <div class="sidebar">
         <NavMenu />


### PR DESCRIPTION
## Summary
- fix layout missing `MudPopoverProvider`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68510a8d10f08322bbd9ff68cdd6cdd5