### PR TITLE
Add PDTree drag-and-drop demo page

### DIFF
--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.6" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.6" PrivateAssets="all" />
     <PackageReference Include="MudBlazor" Version="8.7.0" />
+    <PackageReference Include="PanoramicData.Blazor" Version="9.0.71" />
   </ItemGroup>
 
 </Project>

--- a/Data/TreeDataProvider.cs
+++ b/Data/TreeDataProvider.cs
@@ -1,0 +1,41 @@
+using PanoramicData.Blazor.Interfaces;
+using PanoramicData.Blazor.Models;
+
+namespace BlazorWP.Data;
+
+public class TreeDataProvider : IDataProviderService<TreeItem>
+{
+    private readonly List<TreeItem> _items = new();
+
+    public TreeDataProvider()
+    {
+        _items.Add(new TreeItem { Id = 2, Name = "Sales", ParentId = null, IsGroup = true, Order = 1 });
+        _items.Add(new TreeItem { Id = 11, Name = "Alice", ParentId = 2, Order = 1 });
+        _items.Add(new TreeItem { Id = 16, Name = "Fred", ParentId = 2, Order = 2 });
+        _items.Add(new TreeItem { Id = 21, Name = "Kevin", ParentId = 2, Order = 3 });
+        _items.Add(new TreeItem { Id = 14, Name = "Dave", ParentId = 2, Order = 4 });
+
+        _items.Add(new TreeItem { Id = 3, Name = "Marketing", ParentId = null, IsGroup = true, Order = 2 });
+        _items.Add(new TreeItem { Id = 12, Name = "Bob", ParentId = 3, Order = 1 });
+        _items.Add(new TreeItem { Id = 13, Name = "Carol", ParentId = 3, Order = 2 });
+        _items.Add(new TreeItem { Id = 18, Name = "Harry", ParentId = 3, Order = 3 });
+
+        _items.Add(new TreeItem { Id = 4, Name = "Finance", ParentId = null, IsGroup = true, Order = 3 });
+        _items.Add(new TreeItem { Id = 15, Name = "Emma", ParentId = 4, Order = 1 });
+        _items.Add(new TreeItem { Id = 17, Name = "Gina", ParentId = 4, Order = 2 });
+        _items.Add(new TreeItem { Id = 19, Name = "Ian", ParentId = 4, Order = 3 });
+        _items.Add(new TreeItem { Id = 20, Name = "Janet", ParentId = 4, Order = 4 });
+    }
+
+    public Task<DataResponse<TreeItem>> GetDataAsync(DataRequest<TreeItem> request, CancellationToken cancellationToken)
+        => Task.FromResult(new DataResponse<TreeItem>(_items, _items.Count));
+
+    public Task<OperationResponse> DeleteAsync(TreeItem item, CancellationToken cancellationToken)
+        => Task.FromResult(new OperationResponse { Success = true });
+
+    public Task<OperationResponse> UpdateAsync(TreeItem item, IDictionary<string, object?> delta, CancellationToken cancellationToken)
+        => Task.FromResult(new OperationResponse { Success = true });
+
+    public Task<OperationResponse> CreateAsync(TreeItem item, CancellationToken cancellationToken)
+        => Task.FromResult(new OperationResponse { Success = true });
+}

--- a/Data/TreeItem.cs
+++ b/Data/TreeItem.cs
@@ -1,0 +1,12 @@
+namespace BlazorWP.Data;
+
+public class TreeItem
+{
+    public int Id { get; set; }
+    public int? ParentId { get; set; }
+    public int Order { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public bool IsGroup { get; set; }
+
+    public override string ToString() => $"{Id} - {Name} (order {Order})";
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -34,6 +34,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> MudBlazor Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="drag-tree-demo">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Drag Tree Demo
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -1,0 +1,105 @@
+@page "/drag-tree-demo"
+@using BlazorWP.Data
+@using PanoramicData.Blazor
+@using PanoramicData.Blazor.Arguments
+
+<h3>PDTree Drag-and-Drop Demo</h3>
+<p class="text-muted">Drag nodes to reorder or move between groups.</p>
+
+<PDDragContext>
+    <PDTree @ref="_tree"
+            TItem="TreeItem"
+            DataProvider="_dataProvider"
+            KeyField="x => x.Id"
+            ParentKeyField="x => x.ParentId"
+            TextField="x => x.Name"
+            AllowDrag="true"
+            AllowDrop="true"
+            AllowDropInBetween="true"
+            Drop="OnDrop"
+            Sort="(a,b) => a.Order.CompareTo(b.Order)"
+            ShowLines="true"
+            ShowRoot="true">
+    </PDTree>
+</PDDragContext>
+
+@code {
+    private PDTree<TreeItem> _tree = null!;
+    private readonly TreeDataProvider _dataProvider = new();
+
+    private void OnDrop(DropEventArgs args)
+    {
+        var targetItem = (args.Target as TreeNode<TreeItem>)?.Data;
+        TreeItem? sourceItem = null;
+        if (args.Payload is List<TreeItem> items && items.Count > 0)
+        {
+            sourceItem = items[0];
+        }
+
+        if (sourceItem != null && targetItem != null)
+        {
+            ReOrder(sourceItem, targetItem, args.Before);
+        }
+    }
+
+    private void ReOrder(TreeItem source, TreeItem target, bool? before)
+    {
+        if (source.IsGroup)
+        {
+            if (!target.IsGroup)
+            {
+                return;
+            }
+        }
+        else if (target.IsGroup && before != null)
+        {
+            return;
+        }
+
+        var sourceNode = _tree.RootNode.Find(source.Id.ToString());
+        var targetNode = _tree.RootNode.Find(target.Id.ToString());
+        if (sourceNode?.ParentNode?.Nodes is null || targetNode?.ParentNode?.Nodes is null)
+        {
+            return;
+        }
+
+        sourceNode.ParentNode.Nodes.Remove(sourceNode);
+
+        if (source.IsGroup || !target.IsGroup)
+        {
+            var tIdx = targetNode.ParentNode.Nodes.IndexOf(targetNode);
+            targetNode.ParentNode.Nodes.Insert(before == true ? tIdx : tIdx + 1, sourceNode);
+            sourceNode.ParentNode = targetNode.ParentNode;
+            ReOrderNodes(targetNode.ParentNode.Nodes);
+        }
+        else
+        {
+            targetNode.Nodes?.Add(sourceNode);
+            sourceNode.ParentNode = targetNode;
+            ReOrderNodes(targetNode.Nodes);
+        }
+    }
+
+    private static void ReOrderNodes(IEnumerable<TreeNode<TreeItem>>? nodes)
+    {
+        if (nodes != null)
+        {
+            var index = 0;
+            foreach (var node in nodes)
+            {
+                if (node.Data != null)
+                {
+                    node.Data.Order = ++index;
+                }
+            }
+        }
+    }
+
+    protected override void OnAfterRender(bool firstRender)
+    {
+        if (firstRender)
+        {
+            _tree.ExpandAll();
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorWP;
 using MudBlazor.Services;
+using PanoramicData.Blazor.Extensions;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -9,5 +10,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddMudServices();
+builder.Services.AddPanoramicDataBlazor();
 
 await builder.Build().RunAsync();

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -13,3 +13,6 @@
 @using System.Text
 @using System.Text.Json
 @using MudBlazor
+@using PanoramicData.Blazor
+@using PanoramicData.Blazor.Arguments
+@using BlazorWP.Data


### PR DESCRIPTION
## Summary
- add PanoramicData.Blazor package and services
- add simple TreeItem model and TreeDataProvider
- create DragTreeDemo page demonstrating PDTree drag-and-drop
- expose demo link in NavMenu
- update imports for PanoramicData namespaces

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685130a1f498832287980c1738613e7c