### PR TITLE
Add icons to PDTree drag-and-drop page

### DIFF
--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -14,19 +14,25 @@
             KeyField="x => x.Id"
             ParentKeyField="x => x.ParentId"
             TextField="x => x.Name"
+            IconCssClass="GetIconCssClass"
             AllowDrag="true"
             AllowDrop="true"
             AllowDropInBetween="true"
             Drop="OnDrop"
             Sort="(a,b) => a.Order.CompareTo(b.Order)"
             ShowLines="true"
-            ShowRoot="true">
+            ShowRoot="true"
+            Ready="OnReady">
     </PDTree>
 </PDDragContext>
 
 @code {
     private PDTree<TreeItem> _tree = null!;
     private readonly TreeDataProvider _dataProvider = new();
+
+    private void OnReady() => _tree.ExpandAll();
+
+    private static string GetIconCssClass(TreeItem item, int _) => item.IsGroup ? "fas fa-fw fa-building" : "fas fa-fw fa-user";
 
     private void OnDrop(DropEventArgs args)
     {
@@ -96,11 +102,4 @@
         }
     }
 
-    protected override void OnAfterRender(bool firstRender)
-    {
-        if (firstRender)
-        {
-            _tree.ExpandAll();
-        }
-    }
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -13,6 +13,7 @@
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- include FontAwesome in index.html so PDTree icons render
- enhance `DragTreeDemo` with FontAwesome icons and `Ready` event

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851391247b48322b5268ed42c351afc