### PR TITLE
Add Ant Design Tree drag-and-drop demo

### DIFF
--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.DevServer" Version="9.0.6" PrivateAssets="all" />
     <PackageReference Include="MudBlazor" Version="8.7.0" />
     <PackageReference Include="PanoramicData.Blazor" Version="9.0.71" />
+    <PackageReference Include="AntDesign" Version="1.4.1.1" />
   </ItemGroup>
 
 </Project>

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -39,6 +39,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Drag Tree Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="ant-tree-demo">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Ant Design Demo
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/AntTreeDemo.razor
+++ b/Pages/AntTreeDemo.razor
@@ -1,0 +1,67 @@
+@page "/ant-tree-demo"
+
+<PageTitle>Ant Design Tree Demo</PageTitle>
+
+<h3>Ant Design Tree Drag-and-Drop Demo</h3>
+<p class="text-muted">
+    This example demonstrates using the Ant Design <code>Tree</code> component with
+    drag-and-drop enabled. Drag a node to reorder it or nest it under another
+    node.
+</p>
+<ul>
+    <li>Set <code>Draggable="true"</code> to enable dragging.</li>
+    <li>The tree automatically highlights valid drop targets and expands collapsed nodes on hover.</li>
+    <li>Handle <code>OnDrop</code> to react when a node has been moved.</li>
+</ul>
+
+<Tree TItem="AntTreeNode" DataSource="@treeData" Draggable="true"
+      KeyExpression="@(n => n.Id)"
+      ChildrenExpression="@(n => n.Children)"
+      TitleExpression="@(n => n.Title)"
+      OnDrop="HandleDrop" OnDragStart="HandleDragStart" OnDragEnd="HandleDragEnd">
+</Tree>
+
+@code {
+    private List<AntTreeNode> treeData = new()
+    {
+        new AntTreeNode
+        {
+            Id = 1,
+            Title = "Parent 1",
+            Children = new()
+            {
+                new AntTreeNode { Id = 2, Title = "Child 1-1" },
+                new AntTreeNode { Id = 3, Title = "Child 1-2" }
+            }
+        },
+        new AntTreeNode
+        {
+            Id = 4,
+            Title = "Parent 2"
+        }
+    };
+
+    private void HandleDrop(TreeEventArgs<AntTreeNode> args)
+    {
+        var dragged = args.Node.DataItem.Title;
+        var target = args.TargetNode.DataItem.Title;
+        Console.WriteLine($"Moved '{dragged}' {(args.DropBelow ? "after" : "into")} '{target}'");
+    }
+
+    private void HandleDragStart(TreeEventArgs<AntTreeNode> args)
+    {
+        Console.WriteLine($"Dragging '{args.Node.DataItem.Title}'");
+    }
+
+    private void HandleDragEnd(TreeEventArgs<AntTreeNode> args)
+    {
+        Console.WriteLine($"Finished dragging '{args.Node.DataItem.Title}'");
+    }
+
+    public class AntTreeNode
+    {
+        public int Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public List<AntTreeNode> Children { get; set; } = new();
+    }
+}

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -16,3 +16,4 @@
 @using PanoramicData.Blazor
 @using PanoramicData.Blazor.Arguments
 @using BlazorWP.Data
+@using AntDesign

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -11,6 +11,7 @@
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="BlazorWP.styles.css" rel="stylesheet" />
     <link href="_content/MudBlazor/MudBlazor.min.css" rel="stylesheet" />
+    <link href="_content/AntDesign/css/ant-design-blazor.css" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
 </head>
@@ -31,6 +32,7 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
+    <script src="_content/AntDesign/js/ant-design-blazor.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- add Ant Design drag-and-drop tree demo page
- reference AntDesign package and styles
- include Ant Design menu link
- update imports with AntDesign namespace

## Testing
- `dotnet build BlazorWP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685139835c188322812eb10e8449d2f2