### PR TITLE
Fix compile errors with TreeNode type ambiguity

### DIFF
--- a/Pages/AntTreeDemo.razor
+++ b/Pages/AntTreeDemo.razor
@@ -16,7 +16,7 @@
 
 <Tree TItem="AntTreeNode" DataSource="@treeData" Draggable="true"
       KeyExpression="@(n => n.Id)"
-      ChildrenExpression="@(n => n.Children)"
+      ChildrenExpression="@(n => n.DataItem.Children)"
       TitleExpression="@(n => n.Title)"
       OnDrop="HandleDrop" OnDragStart="HandleDragStart" OnDragEnd="HandleDragEnd">
 </Tree>

--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -36,7 +36,7 @@
 
     private void OnDrop(DropEventArgs args)
     {
-        var targetItem = (args.Target as TreeNode<TreeItem>)?.Data;
+        var targetItem = (args.Target as PanoramicData.Blazor.Models.TreeNode<TreeItem>)?.Data;
         TreeItem? sourceItem = null;
         if (args.Payload is List<TreeItem> items && items.Count > 0)
         {
@@ -87,7 +87,7 @@
         }
     }
 
-    private static void ReOrderNodes(IEnumerable<TreeNode<TreeItem>>? nodes)
+    private static void ReOrderNodes(IEnumerable<PanoramicData.Blazor.Models.TreeNode<TreeItem>>? nodes)
     {
         if (nodes != null)
         {


### PR DESCRIPTION
## Summary
- disambiguate TreeNode usage in drag demo
- fix Ant Design tree child expression

## Testing
- `dotnet build`
- `dotnet run`

------
https://chatgpt.com/codex/tasks/task_e_68513d38814483229b59e0a5fc29c383