### PR TITLE
Fix AntTreeDemo service injection

### DIFF
--- a/App.razor
+++ b/App.razor
@@ -10,3 +10,4 @@
         </LayoutView>
     </NotFound>
 </Router>
+<AntContainer />

--- a/Program.cs
+++ b/Program.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorWP;
 using MudBlazor.Services;
 using PanoramicData.Blazor.Extensions;
+using AntDesign;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -11,5 +12,6 @@ builder.RootComponents.Add<HeadOutlet>("head::after");
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 builder.Services.AddMudServices();
 builder.Services.AddPanoramicDataBlazor();
+builder.Services.AddAntDesign();
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- register Ant Design services on startup
- add `AntContainer` to `App.razor` for AntDesign popups

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68514172525c832287583b7a4e17d567