### PR TITLE
Fix Ant Design tree title binding

### DIFF
--- a/Pages/AntTreeDemo.razor
+++ b/Pages/AntTreeDemo.razor
@@ -17,7 +17,7 @@
 <Tree TItem="AntTreeNode" DataSource="@treeData" Draggable="true"
       KeyExpression="@(n => n.Id)"
       ChildrenExpression="@(n => n.DataItem.Children)"
-      TitleExpression="@(n => n.Title)"
+      TitleExpression="@(n => n.DataItem.Title)"
       OnDrop="HandleDrop" OnDragStart="HandleDragStart" OnDragEnd="HandleDragEnd">
 </Tree>
 


### PR DESCRIPTION
## Summary
- avoid recursive property access in AntTreeDemo

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6851428ccbe08322ad1e4c294c8c4711