### PR TITLE
Improve PDTree drag highlight

### DIFF
--- a/wwwroot/js/pdTreeHighlight.js
+++ b/wwwroot/js/pdTreeHighlight.js
@@ -1,26 +1,66 @@
 function setupPDTreeHighlight() {
-  document.addEventListener('dragenter', function(e) {
-    var node = e.target.closest('.pdtreenode_content');
-    if (node) {
+  const counters = new WeakMap();
+
+  const addHighlight = (node) => {
+    const count = counters.get(node) || 0;
+    if (count === 0) {
       node.classList.add('drop-target');
     }
-  });
-  document.addEventListener('dragleave', function(e) {
-    var node = e.target.closest('.pdtreenode_content');
-    if (node) {
-      node.classList.remove('drop-target');
+    counters.set(node, count + 1);
+  };
+
+  const removeHighlight = (node) => {
+    let count = counters.get(node) || 0;
+    if (count > 0) {
+      count--;
+      counters.set(node, count);
+      if (count === 0) {
+        node.classList.remove('drop-target');
+      }
     }
-  });
-  document.addEventListener('drop', function(e) {
-    var node = e.target.closest('.pdtreenode_content');
-    if (node) {
-      node.classList.remove('drop-target');
-    }
-  });
-  document.addEventListener('dragend', function(e) {
-    document.querySelectorAll('.pdtreenode_content.drop-target').forEach(function(el) {
-      el.classList.remove('drop-target');
-    });
+  };
+
+  document.addEventListener(
+    'dragenter',
+    function (e) {
+      const node = e.target.closest('.pdtreenode_content');
+      if (node) {
+        addHighlight(node);
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    'dragleave',
+    function (e) {
+      const node = e.target.closest('.pdtreenode_content');
+      if (node) {
+        removeHighlight(node);
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    'drop',
+    function (e) {
+      const node = e.target.closest('.pdtreenode_content');
+      if (node) {
+        counters.set(node, 0);
+        node.classList.remove('drop-target');
+      }
+    },
+    true
+  );
+
+  document.addEventListener('dragend', function () {
+    document
+      .querySelectorAll('.pdtreenode_content.drop-target')
+      .forEach((el) => {
+        counters.set(el, 0);
+        el.classList.remove('drop-target');
+      });
   });
 }
 


### PR DESCRIPTION
## Summary
- make drop-target highlighting stable by tracking nested drag events

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685159595eb083229956e8538abc08d6