### PR TITLE
Fix tree folder nesting

### DIFF
--- a/Data/TreeDataProvider.cs
+++ b/Data/TreeDataProvider.cs
@@ -49,7 +49,18 @@ public class TreeDataProvider : IDataProviderService<TreeItem>
         => Task.FromResult(new OperationResponse { Success = true });
 
     public Task<OperationResponse> UpdateAsync(TreeItem item, IDictionary<string, object?> delta, CancellationToken cancellationToken)
-        => Task.FromResult(new OperationResponse { Success = true });
+    {
+        var existing = _items.FirstOrDefault(x => x.Id == item.Id);
+        if (existing != null)
+        {
+            existing.ParentId = item.ParentId;
+            existing.Order = item.Order;
+            existing.Name = item.Name;
+            existing.IsGroup = item.IsGroup;
+        }
+
+        return Task.FromResult(new OperationResponse { Success = true });
+    }
 
     public Task<OperationResponse> CreateAsync(TreeItem item, CancellationToken cancellationToken)
         => Task.FromResult(new OperationResponse { Success = true });

--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -65,7 +65,24 @@
 
         var sourceNode = _tree.RootNode.Find(source.Id.ToString());
         var targetNode = _tree.RootNode.Find(target.Id.ToString());
-        if (sourceNode?.ParentNode?.Nodes is null || targetNode?.ParentNode?.Nodes is null)
+        if (sourceNode?.ParentNode?.Nodes is null || targetNode == null)
+        {
+            return;
+        }
+
+        // Handle folder dropped onto folder to make it a child
+        if (source.IsGroup && target.IsGroup && before == null)
+        {
+            sourceNode.ParentNode.Nodes.Remove(sourceNode);
+            targetNode.Nodes?.Add(sourceNode);
+            sourceNode.ParentNode = targetNode;
+            source.ParentId = target.Id;
+            ReOrderNodes(targetNode.Nodes);
+            _ = _dataProvider.UpdateAsync(source, new Dictionary<string, object?> { ["ParentId"] = source.ParentId }, CancellationToken.None);
+            return;
+        }
+
+        if (targetNode.ParentNode?.Nodes is null)
         {
             return;
         }
@@ -77,13 +94,17 @@
             var tIdx = targetNode.ParentNode.Nodes.IndexOf(targetNode);
             targetNode.ParentNode.Nodes.Insert(before == true ? tIdx : tIdx + 1, sourceNode);
             sourceNode.ParentNode = targetNode.ParentNode;
+            source.ParentId = (targetNode.ParentNode.Data as TreeItem)?.Id;
             ReOrderNodes(targetNode.ParentNode.Nodes);
+            _ = _dataProvider.UpdateAsync(source, new Dictionary<string, object?> { ["ParentId"] = source.ParentId }, CancellationToken.None);
         }
         else
         {
             targetNode.Nodes?.Add(sourceNode);
             sourceNode.ParentNode = targetNode;
+            source.ParentId = target.Id;
             ReOrderNodes(targetNode.Nodes);
+            _ = _dataProvider.UpdateAsync(source, new Dictionary<string, object?> { ["ParentId"] = source.ParentId }, CancellationToken.None);
         }
     }
 


### PR DESCRIPTION
## Summary
- handle folder-to-folder drops in `DragTreeDemo` so groups can be nested
- persist tree changes in `TreeDataProvider`

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685210f15ebc832289304d51e06abe86