### PR TITLE
Hide PDTree expand icons in demo

### DIFF
--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -7,6 +7,7 @@
 <h3>PDTree Drag-and-Drop Demo</h3>
 <p class="text-muted">Drag nodes to reorder or move between folders. This sample demonstrates a simple hierarchical structure.</p>
 
+<div class="drag-tree-demo">
 <PDDragContext>
     <PDTree @ref="_tree"
             TItem="TreeItem"
@@ -25,6 +26,7 @@
             Ready="OnReady">
     </PDTree>
 </PDDragContext>
+</div>
 
 @code {
     private PDTree<TreeItem> _tree = null!;

--- a/Pages/DragTreeDemo.razor.css
+++ b/Pages/DragTreeDemo.razor.css
@@ -1,0 +1,4 @@
+.drag-tree-demo .pdtreenode_header > i.fa-plus-square,
+.drag-tree-demo .pdtreenode_header > i.fa-minus-square {
+    color: transparent;
+}


### PR DESCRIPTION
## Summary
- wrap `PDTree` demo in a container and add CSS isolation
- hide the plus and minus expand icons in the drag tree demo

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6852129ba0288322a26a5104dcd4cb91