### PR TITLE
Enable PDTree toggle via label or icon

### DIFF
--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -135,3 +135,15 @@ code {
 .pdtreenode_content.drop-target {
     background-color: #80bfff;
 }
+
+/* Hide default expand/collapse icons in PDTree */
+.pdtreenode_header .fa-plus-square,
+.pdtreenode_header .fa-minus-square {
+    display: none;
+}
+
+/* Indicate clickable areas for toggling */
+.pdtreenode_content > span,
+.pdtreenode_content > i:not(.fa-plus-square):not(.fa-minus-square) {
+    cursor: pointer;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -35,6 +35,7 @@
     <script src="_content/MudBlazor/MudBlazor.min.js"></script>
     <script src="_content/AntDesign/js/ant-design-blazor.js"></script>
     <script src="js/pdTreeHighlight.js"></script>
+    <script src="js/pdTreeToggle.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/pdTreeToggle.js
+++ b/wwwroot/js/pdTreeToggle.js
@@ -1,0 +1,20 @@
+function setupPDTreeToggle() {
+  document.addEventListener('click', function (e) {
+    const target = e.target;
+    const header = target.closest('.pdtreenode_header');
+    if (!header) return;
+    const toggler = header.querySelector('.fa-plus-square, .fa-minus-square');
+    if (!toggler) return;
+    const isIcon = target.matches('i') && !target.classList.contains('fa-plus-square') && !target.classList.contains('fa-minus-square');
+    const isSpan = target.matches('.pdtreenode_content > span');
+    if (isIcon || isSpan) {
+      toggler.click();
+    }
+  });
+
+  document.querySelectorAll('.pdtreenode_header .fa-plus-square, .pdtreenode_header .fa-minus-square').forEach(el => {
+    el.style.display = 'none';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', setupPDTreeToggle);


### PR DESCRIPTION
## Summary
- hide default plus/minus icons
- toggle tree nodes by clicking the item icon or text
- load new toggle script in the demo page

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685216fc78288322bc373f33c7d352ed