### PR TITLE
Sort PDTree people before folders

### DIFF
--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -19,7 +19,7 @@
             AllowDrop="true"
             AllowDropInBetween="true"
             Drop="OnDrop"
-            Sort="(a,b) => a.Order.CompareTo(b.Order)"
+            Sort="SortTreeItems"
             ShowLines="true"
             ShowRoot="true"
             Ready="OnReady">
@@ -106,6 +106,16 @@
             ReOrderNodes(targetNode.Nodes);
             _ = _dataProvider.UpdateAsync(source, new Dictionary<string, object?> { ["ParentId"] = source.ParentId }, CancellationToken.None);
         }
+    }
+
+    private static int SortTreeItems(TreeItem a, TreeItem b)
+    {
+        if (a.IsGroup == b.IsGroup)
+        {
+            return a.Order.CompareTo(b.Order);
+        }
+
+        return a.IsGroup ? 1 : -1;
     }
 
     private static void ReOrderNodes(IEnumerable<PanoramicData.Blazor.Models.TreeNode<TreeItem>>? nodes)


### PR DESCRIPTION
## Summary
- update PDTree sample sorting so that people appear before folders

## Testing
- `dotnet build BlazorWP.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223dc8d28832297ba5302c3e7726a