### PR TITLE
Add Bootstrap Icons with demo page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ bld/
 .vs/
 # Uncomment if you have tasks that create the project's static files in wwwroot
 #wwwroot/
+wwwroot/libman/
 
 # Visual Studio 2017 auto generated files
 Generated\ Files/

--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="MudBlazor" Version="8.7.0" />
     <PackageReference Include="PanoramicData.Blazor" Version="9.0.71" />
     <PackageReference Include="AntDesign" Version="1.4.1.1" />
+    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="2.1.113" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -44,6 +44,11 @@
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Ant Design Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="bootstrap-icons-demo">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> Icons Demo
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/BootstrapIconsDemo.razor
+++ b/Pages/BootstrapIconsDemo.razor
@@ -1,0 +1,26 @@
+@page "/bootstrap-icons-demo"
+
+<PageTitle>Bootstrap Icons Demo</PageTitle>
+
+<h3>Bootstrap Icons Demo</h3>
+
+<p>The Bootstrap Icons library was added via LibMan. Below are a few sample icons using the <code>bi</code> classes.</p>
+
+<div class="d-flex gap-3 flex-wrap">
+    <div class="text-center">
+        <i class="bi bi-alarm" style="font-size: 2rem;" aria-hidden="true"></i>
+        <div>alarm</div>
+    </div>
+    <div class="text-center">
+        <i class="bi bi-basket" style="font-size: 2rem;" aria-hidden="true"></i>
+        <div>basket</div>
+    </div>
+    <div class="text-center">
+        <i class="bi bi-bezier" style="font-size: 2rem;" aria-hidden="true"></i>
+        <div>bezier</div>
+    </div>
+    <div class="text-center">
+        <i class="bi bi-brush" style="font-size: 2rem;" aria-hidden="true"></i>
+        <div>brush</div>
+    </div>
+</div>

--- a/libman.json
+++ b/libman.json
@@ -1,0 +1,15 @@
+{
+  "version": "1.0",
+  "defaultProvider": "jsdelivr",
+  "libraries": [
+    {
+      "library": "bootstrap-icons@1.11.3",
+      "destination": "wwwroot/libman/bootstrap-icons/",
+      "files": [
+        "font/bootstrap-icons.min.css",
+        "font/fonts/bootstrap-icons.woff",
+        "font/fonts/bootstrap-icons.woff2"
+      ]
+    }
+  ]
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -7,6 +7,7 @@
     <title>BlazorWP</title>
     <base href="/" />
     <link rel="stylesheet" href="lib/bootstrap/dist/css/bootstrap.min.css" />
+    <link rel="stylesheet" href="libman/bootstrap-icons/font/bootstrap-icons.min.css" />
     <link rel="stylesheet" href="css/app.css" />
     <link rel="icon" type="image/png" href="favicon.png" />
     <link href="BlazorWP.styles.css" rel="stylesheet" />


### PR DESCRIPTION
## Summary
- install Bootstrap Icons library files via LibMan config
- include Bootstrap Icons CSS in index.html
- add a demo page that shows example icons
- link to the demo from the navigation menu
- integrate LibMan into builds and ignore restored files

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685223b2faf08322953129c17f188ad2