### PR TITLE
Prioritize people in PDTree sorting

### DIFF
--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -19,7 +19,7 @@
             AllowDrop="true"
             AllowDropInBetween="true"
             Drop="OnDrop"
-            Sort="(a,b) => a.Order.CompareTo(b.Order)"
+            Sort="SortNodes"
             ShowLines="true"
             ShowRoot="true"
             Ready="OnReady">
@@ -46,7 +46,18 @@
         if (sourceItem != null && targetItem != null)
         {
             ReOrder(sourceItem, targetItem, args.Before);
+            _tree.Refresh();
         }
+    }
+
+    private static int SortNodes(TreeItem a, TreeItem b)
+    {
+        if (a.IsGroup != b.IsGroup)
+        {
+            return a.IsGroup ? 1 : -1;
+        }
+
+        return a.Order.CompareTo(b.Order);
     }
 
     private void ReOrder(TreeItem source, TreeItem target, bool? before)


### PR DESCRIPTION
## Summary
- update DragTree demo tree sorting logic
- show people before folders at each hierarchy level

## Testing
- `dotnet build BlazorWP.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6852298d69c4832289f001ada489c5dd