### PR TITLE
Fix PDTree dropped item ordering

### DIFF
--- a/Pages/DragTreeDemo.razor
+++ b/Pages/DragTreeDemo.razor
@@ -112,7 +112,7 @@
         {
             var sourceParentNodes = sourceNode.ParentNode.Nodes;
             sourceParentNodes.Remove(sourceNode);
-            targetNode.Nodes?.Add(sourceNode);
+            targetNode.Nodes?.Insert(0, sourceNode);
             sourceNode.ParentNode = targetNode;
             source.ParentId = target.Id;
             ReOrderNodes(sourceParentNodes);
@@ -141,7 +141,7 @@
         }
         else
         {
-            targetNode.Nodes?.Add(sourceNode);
+            targetNode.Nodes?.Insert(0, sourceNode);
             sourceNode.ParentNode = targetNode;
             source.ParentId = target.Id;
             ReOrderNodes(originalParentNodes);


### PR DESCRIPTION
## Summary
- adjust `DragTreeDemo` so dropping into a folder inserts the node at the top of the folder

## Testing
- `dotnet build` *(fails: bootstrap-icons library from jsdelivr blocked)*
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_68523e415be48322a1fe105e6ec87ad3