### PR TITLE
Add MudBlazor and Ant Design API viewers

### DIFF
--- a/Data/JsonTreeNode.cs
+++ b/Data/JsonTreeNode.cs
@@ -1,0 +1,11 @@
+namespace BlazorWP.Data;
+
+public class JsonTreeNode
+{
+    public string Name { get; set; } = string.Empty;
+    public string? Value { get; set; }
+    public bool IsLeaf { get; set; }
+    public List<JsonTreeNode> Children { get; set; } = new();
+
+    public string Display => IsLeaf && Value != null ? $"{Name}: {Value}" : Name;
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -30,6 +30,16 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="api-mud">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> API MudBlazor
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="api-ant">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> API Ant Design
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="mud-demo">
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> MudBlazor Demo
             </NavLink>

--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -1,0 +1,102 @@
+@page "/api-ant"
+@using System.Text.Json
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+<PageTitle>Ant Design API Viewer</PageTitle>
+
+<h1>Ant Design API Viewer</h1>
+
+@if (loading)
+{
+    <p><em>Loading...</em></p>
+}
+else if (error != null)
+{
+    <p class="text-danger">@error</p>
+}
+else if (rootNodes != null)
+{
+    <Tree TItem="AntJsonNode" DataSource="@rootNodes" KeyExpression="n => n.Id" ChildrenExpression="n => n.Children" TitleExpression="n => n.Title"></Tree>
+}
+else if (formattedJson != null)
+{
+    <pre class="json-view">@formattedJson</pre>
+}
+else
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+
+@code {
+    private string? formattedJson;
+    private string? error;
+    private bool loading = true;
+    private List<AntJsonNode>? rootNodes;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            loading = false;
+            return;
+        }
+
+        var rootEndpoint = endpoint;
+        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
+        {
+            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
+        }
+
+        try
+        {
+            var json = await Http.GetStringAsync(rootEndpoint);
+            using var doc = JsonDocument.Parse(json);
+            formattedJson = JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+            var root = BuildNode(doc.RootElement, "root");
+            rootNodes = root.Children;
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private static AntJsonNode BuildNode(JsonElement element, string name)
+    {
+        var node = new AntJsonNode { Id = Guid.NewGuid().ToString(), Title = name };
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    node.Children.Add(BuildNode(prop.Value, prop.Name));
+                }
+                break;
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var val in element.EnumerateArray())
+                {
+                    node.Children.Add(BuildNode(val, $"[{index}]"));
+                    index++;
+                }
+                break;
+            default:
+                node.Title = $"{name}: {element}";
+                break;
+        }
+        return node;
+    }
+
+    public class AntJsonNode
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Title { get; set; } = string.Empty;
+        public List<AntJsonNode> Children { get; set; } = new();
+    }
+}

--- a/Pages/ApiViewerMud.razor
+++ b/Pages/ApiViewerMud.razor
@@ -1,0 +1,119 @@
+@page "/api-mud"
+@using System.Text.Json
+@inject HttpClient Http
+@inject IJSRuntime JS
+
+<PageTitle>Mud API Viewer</PageTitle>
+
+<h1>MudBlazor API Viewer</h1>
+
+@if (loading)
+{
+    <p><em>Loading...</em></p>
+}
+else if (error != null)
+{
+    <p class="text-danger">@error</p>
+}
+else if (rootNode != null)
+{
+    <MudTreeView>
+        @foreach (var child in rootNode.Children)
+        {
+            @BuildMudItem(child)
+        }
+    </MudTreeView>
+}
+else if (formattedJson != null)
+{
+    <pre class="json-view">@formattedJson</pre>
+}
+else
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+
+@code {
+    private string? formattedJson;
+    private string? error;
+    private bool loading = true;
+    private JsonTreeNode? rootNode;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            loading = false;
+            return;
+        }
+
+        var rootEndpoint = endpoint;
+        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
+        {
+            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
+        }
+
+        try
+        {
+            var json = await Http.GetStringAsync(rootEndpoint);
+            using var doc = JsonDocument.Parse(json);
+            formattedJson = JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
+            rootNode = BuildNode(doc.RootElement, "root");
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+        finally
+        {
+            loading = false;
+        }
+    }
+
+    private static JsonTreeNode BuildNode(JsonElement element, string name)
+    {
+        var node = new JsonTreeNode { Name = name };
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    node.Children.Add(BuildNode(prop.Value, prop.Name));
+                }
+                break;
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var val in element.EnumerateArray())
+                {
+                    node.Children.Add(BuildNode(val, $"[{index}]"));
+                    index++;
+                }
+                break;
+            default:
+                node.IsLeaf = true;
+                node.Value = element.ToString();
+                break;
+        }
+        return node;
+    }
+
+    private RenderFragment BuildMudItem(JsonTreeNode node) => builder =>
+    {
+        var seq = 0;
+        builder.OpenComponent<MudTreeViewItem>(seq++);
+        builder.AddAttribute(seq++, "Text", node.Display);
+        builder.AddAttribute(seq++, "Icon", node.IsLeaf ? Icons.Material.Filled.Description : Icons.Material.Filled.Folder);
+        if (node.Children.Count > 0)
+        {
+            builder.AddAttribute(seq++, "ChildContent", (RenderFragment)(b =>
+            {
+                foreach (var child in node.Children)
+                {
+                    b.AddContent(seq++, BuildMudItem(child));
+                }
+            }));
+        }
+        builder.CloseComponent();
+    };
+}


### PR DESCRIPTION
## Summary
- add a shared `JsonTreeNode` model for hierarchical data
- implement MudBlazor version of API viewer
- implement Ant Design version of API viewer
- link the new pages from the nav menu

## Testing
- `dotnet build BlazorWP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68524706342c8322ac3107855a935d78