### PR TITLE
Fix generic types in API viewer pages

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -15,10 +15,10 @@ else if (error != null)
 {
     <p class="text-danger">@error</p>
 }
-else if (rootNodes != null)
-{
-    <Tree TItem="AntJsonNode" DataSource="@rootNodes" KeyExpression="n => n.Id" ChildrenExpression="n => n.Children" TitleExpression="n => n.Title"></Tree>
-}
+    else if (rootNodes != null)
+    {
+        <Tree TItem="AntJsonNode" DataSource="@rootNodes" KeyExpression="n => n.Id" ChildrenExpression="n => n.DataItem.Children" TitleExpression="n => n.DataItem.Title"></Tree>
+    }
 else if (formattedJson != null)
 {
     <pre class="json-view">@formattedJson</pre>

--- a/Pages/ApiViewerMud.razor
+++ b/Pages/ApiViewerMud.razor
@@ -15,14 +15,14 @@ else if (error != null)
 {
     <p class="text-danger">@error</p>
 }
-else if (rootNode != null)
-{
-    <MudTreeView>
-        @foreach (var child in rootNode.Children)
-        {
-            @BuildMudItem(child)
-        }
-    </MudTreeView>
+    else if (rootNode != null)
+    {
+        <MudTreeView T="JsonTreeNode">
+            @foreach (var child in rootNode.Children)
+            {
+                @BuildMudItem(child)
+            }
+        </MudTreeView>
 }
 else if (formattedJson != null)
 {
@@ -101,7 +101,7 @@ else
     private RenderFragment BuildMudItem(JsonTreeNode node) => builder =>
     {
         var seq = 0;
-        builder.OpenComponent<MudTreeViewItem>(seq++);
+        builder.OpenComponent<MudTreeViewItem<JsonTreeNode>>(seq++);
         builder.AddAttribute(seq++, "Text", node.Display);
         builder.AddAttribute(seq++, "Icon", node.IsLeaf ? Icons.Material.Filled.Description : Icons.Material.Filled.Folder);
         if (node.Children.Count > 0)


### PR DESCRIPTION
## Summary
- specify JsonTreeNode type for `MudTreeView` and `MudTreeViewItem`
- correct `ChildrenExpression` and `TitleExpression` in Ant Design API viewer

## Testing
- `dotnet build` *(fails: libman could not download bootstrap-icons)*

------
https://chatgpt.com/codex/tasks/task_e_6852493969108322ad2abc2c343912af