### PR TITLE
Cache tree data for Ant API viewer

### DIFF
--- a/Data/AntJsonNode.cs
+++ b/Data/AntJsonNode.cs
@@ -1,0 +1,8 @@
+namespace BlazorWP.Data;
+
+public class AntJsonNode
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Title { get; set; } = string.Empty;
+    public List<AntJsonNode> Children { get; set; } = new();
+}

--- a/Data/TreeState.cs
+++ b/Data/TreeState.cs
@@ -1,0 +1,72 @@
+using System.Text.Json;
+using BlazorWP.Data;
+using Microsoft.JSInterop;
+
+namespace BlazorWP.Data;
+
+public class TreeState
+{
+    public List<AntJsonNode>? Nodes { get; private set; }
+    public IEnumerable<string> ExpandedKeys { get; set; } = Array.Empty<string>();
+    public string? SelectedKey { get; set; }
+
+    private readonly HttpClient _http;
+    private readonly IJSRuntime _js;
+
+    public TreeState(HttpClient http, IJSRuntime js)
+    {
+        _http = http;
+        _js = js;
+    }
+
+    public async Task EnsureLoadedAsync()
+    {
+        if (Nodes != null)
+        {
+            return;
+        }
+
+        var endpoint = await _js.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return;
+        }
+
+        var rootEndpoint = endpoint;
+        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
+        {
+            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
+        }
+
+        var json = await _http.GetStringAsync(rootEndpoint);
+        using var doc = JsonDocument.Parse(json);
+        var root = BuildNode(doc.RootElement, "root");
+        Nodes = root.Children;
+    }
+
+    private static AntJsonNode BuildNode(JsonElement element, string name)
+    {
+        var node = new AntJsonNode { Id = Guid.NewGuid().ToString(), Title = name };
+        switch (element.ValueKind)
+        {
+            case JsonValueKind.Object:
+                foreach (var prop in element.EnumerateObject())
+                {
+                    node.Children.Add(BuildNode(prop.Value, prop.Name));
+                }
+                break;
+            case JsonValueKind.Array:
+                var index = 0;
+                foreach (var val in element.EnumerateArray())
+                {
+                    node.Children.Add(BuildNode(val, $"[{index}]"));
+                    index++;
+                }
+                break;
+            default:
+                node.Title = $"{name}: {element}";
+                break;
+        }
+        return node;
+    }
+}

--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -1,7 +1,7 @@
 @page "/api-ant"
 @using System.Text.Json
-@inject HttpClient Http
-@inject IJSRuntime JS
+@using BlazorWP.Data
+@inject TreeState TreeState
 
 <PageTitle>Ant Design API Viewer</PageTitle>
 
@@ -15,9 +15,17 @@ else if (error != null)
 {
     <p class="text-danger">@error</p>
 }
-    else if (rootNodes != null)
+    else if (TreeState.Nodes != null)
     {
-        <Tree TItem="AntJsonNode" DataSource="@rootNodes" KeyExpression="n => n.Id" ChildrenExpression="n => n.DataItem.Children" TitleExpression="n => n.DataItem.Title"></Tree>
+        <Tree TItem="AntJsonNode"
+              DataSource="@TreeState.Nodes"
+              KeyExpression="n => n.Id"
+              ChildrenExpression="n => n.DataItem.Children"
+              TitleExpression="n => n.DataItem.Title"
+              ExpandedKeys="TreeState.ExpandedKeys"
+              SelectedKeys="new[] { TreeState.SelectedKey }"
+              OnExpand="OnExpand"
+              OnSelect="OnSelect"></Tree>
     }
 else if (formattedJson != null)
 {
@@ -32,30 +40,15 @@ else
     private string? formattedJson;
     private string? error;
     private bool loading = true;
-    private List<AntJsonNode>? rootNodes;
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
-        if (string.IsNullOrEmpty(endpoint))
-        {
-            loading = false;
-            return;
-        }
-
-        var rootEndpoint = endpoint;
-        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
-        {
-            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
-        }
-
         try
         {
-            var json = await Http.GetStringAsync(rootEndpoint);
-            using var doc = JsonDocument.Parse(json);
-            formattedJson = JsonSerializer.Serialize(doc.RootElement, new JsonSerializerOptions { WriteIndented = true });
-            var root = BuildNode(doc.RootElement, "root");
-            rootNodes = root.Children;
+            await TreeState.EnsureLoadedAsync();
+            formattedJson = TreeState.Nodes != null
+                ? JsonSerializer.Serialize(TreeState.Nodes, new JsonSerializerOptions { WriteIndented = true })
+                : null;
         }
         catch (Exception ex)
         {
@@ -67,36 +60,7 @@ else
         }
     }
 
-    private static AntJsonNode BuildNode(JsonElement element, string name)
-    {
-        var node = new AntJsonNode { Id = Guid.NewGuid().ToString(), Title = name };
-        switch (element.ValueKind)
-        {
-            case JsonValueKind.Object:
-                foreach (var prop in element.EnumerateObject())
-                {
-                    node.Children.Add(BuildNode(prop.Value, prop.Name));
-                }
-                break;
-            case JsonValueKind.Array:
-                var index = 0;
-                foreach (var val in element.EnumerateArray())
-                {
-                    node.Children.Add(BuildNode(val, $"[{index}]"));
-                    index++;
-                }
-                break;
-            default:
-                node.Title = $"{name}: {element}";
-                break;
-        }
-        return node;
-    }
+    private void OnExpand(IEnumerable<string> keys, object info) => TreeState.ExpandedKeys = keys;
 
-    public class AntJsonNode
-    {
-        public string Id { get; set; } = Guid.NewGuid().ToString();
-        public string Title { get; set; } = string.Empty;
-        public List<AntJsonNode> Children { get; set; } = new();
-    }
+    private void OnSelect(string[] keys, object info) => TreeState.SelectedKey = keys.FirstOrDefault();
 }

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using BlazorWP;
 using MudBlazor.Services;
 using PanoramicData.Blazor.Extensions;
 using AntDesign;
+using BlazorWP.Data;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 builder.RootComponents.Add<App>("#app");
@@ -13,5 +14,6 @@ builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.
 builder.Services.AddMudServices();
 builder.Services.AddPanoramicDataBlazor();
 builder.Services.AddAntDesign();
+builder.Services.AddScoped<TreeState>();
 
 await builder.Build().RunAsync();


### PR DESCRIPTION
## Summary
- create `TreeState` service to cache Ant tree data and UI state
- move `AntJsonNode` model to `Data` folder
- inject `TreeState` into `ApiViewerAnt` and remember expanded/selected nodes
- register `TreeState` in `Program`

## Testing
- `dotnet build -c Release` *(fails: NETSDK1045 - current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68524d26c13883229413e1224595b118