### PR TITLE
Fix event binding for Ant Design Tree

### DIFF
--- a/Data/TreeState.cs
+++ b/Data/TreeState.cs
@@ -7,7 +7,7 @@ namespace BlazorWP.Data;
 public class TreeState
 {
     public List<AntJsonNode>? Nodes { get; private set; }
-    public IEnumerable<string> ExpandedKeys { get; set; } = Array.Empty<string>();
+    public string[] ExpandedKeys { get; set; } = Array.Empty<string>();
     public string? SelectedKey { get; set; }
 
     private readonly HttpClient _http;

--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -22,10 +22,10 @@ else if (error != null)
               KeyExpression="n => n.Id"
               ChildrenExpression="n => n.DataItem.Children"
               TitleExpression="n => n.DataItem.Title"
-              ExpandedKeys="TreeState.ExpandedKeys"
+              ExpandedKeys="TreeState.ExpandedKeys.ToArray()"
               SelectedKeys="new[] { TreeState.SelectedKey }"
-              OnExpand="OnExpand"
-              OnSelect="OnSelect"></Tree>
+              OnExpandChanged="OnExpand"
+              SelectedKeysChanged="OnSelect"></Tree>
     }
 else if (formattedJson != null)
 {
@@ -60,7 +60,13 @@ else
         }
     }
 
-    private void OnExpand(IEnumerable<string> keys, object info) => TreeState.ExpandedKeys = keys;
+    private void OnExpand(string[] keys)
+    {
+        TreeState.ExpandedKeys = keys;
+    }
 
-    private void OnSelect(string[] keys, object info) => TreeState.SelectedKey = keys.FirstOrDefault();
+    private void OnSelect(string[] keys)
+    {
+        TreeState.SelectedKey = keys.FirstOrDefault();
+    }
 }


### PR DESCRIPTION
## Summary
- fix tree event handler names for Ant Design Tree
- update parameter types for OnExpand and OnSelect
- store tree expanded keys in a `string[]`

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68524e53cb308322a18d6678a3ad067e