### PR TITLE
Fix tree event binding

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -24,7 +24,7 @@ else if (error != null)
               TitleExpression="n => n.DataItem.Title"
               ExpandedKeys="TreeState.ExpandedKeys.ToArray()"
               SelectedKeys="new[] { TreeState.SelectedKey }"
-              OnExpandChanged="OnExpand"
+              ExpandedKeysChanged="OnExpand"
               SelectedKeysChanged="OnSelect"></Tree>
     }
 else if (formattedJson != null)


### PR DESCRIPTION
## Summary
- use `ExpandedKeysChanged` event for Ant tree component

## Testing
- `dotnet build -c Release -p:LibraryRestore=false`

------
https://chatgpt.com/codex/tasks/task_e_6852500356d48322899852d72d8d5847