### PR TITLE
Fix localStorage handling for favorites

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -34,17 +34,20 @@ else
     private string? error;
     private bool loading = true;
     private List<AntJsonNode>? rootNodes;
-    private RenderFragment<TreeNode<AntJsonNode>> TitleWithFavorite => node => @<div class="d-flex justify-content-between align-items-center"><span>@node.DataItem.Title</span><button class="btn btn-link btn-sm" @onclick="() => AddFavorite(node.DataItem)" title="Add to favorites">☆</button></div>;
+    private RenderFragment<TreeNode<AntJsonNode>> TitleWithFavorite => node => @<div class="d-flex justify-content-between align-items-center"><span>@node.DataItem.Title</span><button class="btn btn-link btn-sm" @onclick="async () => await AddFavorite(node.DataItem)" title="Add to favorites">☆</button></div>;
 
     private async Task AddFavorite(AntJsonNode node)
     {
+        Console.WriteLine($"[AddFavorite] Adding {node.Path}");
         var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        Console.WriteLine($"[AddFavorite] Endpoint: {endpoint}");
         if (string.IsNullOrEmpty(endpoint))
         {
             return;
         }
 
         var json = await JS.InvokeAsync<string?>("localStorage.getItem", "favoriteApis");
+        Console.WriteLine($"[AddFavorite] Current JSON: {json}");
         Dictionary<string, List<string>> data;
         if (!string.IsNullOrEmpty(json))
         {
@@ -73,6 +76,8 @@ else
             list.Add(node.Path);
             var serialized = JsonSerializer.Serialize(data);
             await JS.InvokeVoidAsync("localStorage.setItem", "favoriteApis", serialized);
+            var verify = await JS.InvokeAsync<string?>("localStorage.getItem", "favoriteApis");
+            Console.WriteLine($"[AddFavorite] Stored JSON: {verify}");
         }
     }
 

--- a/Pages/DataStorage.razor
+++ b/Pages/DataStorage.razor
@@ -46,13 +46,11 @@ else
     protected override async Task OnInitializedAsync()
     {
         items = new();
-        foreach (var key in new[] { "wpEndpoint" })
+        var keys = await JS.InvokeAsync<string[]>("blazorwpStorage.keys");
+        foreach (var key in keys)
         {
             var value = await JS.InvokeAsync<string?>("localStorage.getItem", key);
-            if (value != null)
-            {
-                items[key] = value;
-            }
+            items[key] = value;
         }
     }
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -37,6 +37,7 @@
     <script src="_content/AntDesign/js/ant-design-blazor.js"></script>
     <script src="js/pdTreeHighlight.js"></script>
     <script src="js/pdTreeToggle.js"></script>
+    <script src="js/storageUtils.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/storageUtils.js
+++ b/wwwroot/js/storageUtils.js
@@ -1,0 +1,3 @@
+window.blazorwpStorage = {
+  keys: () => Object.keys(window.localStorage)
+};


### PR DESCRIPTION
## Summary
- make favorite button event async and log details
- verify favorites saved to localStorage
- show all localStorage values in Data Storage page
- include JS helper for retrieving localStorage keys

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68526aa127708322adde5b7c4102c09b