### PR TITLE
Fix first Enter key handling on home page

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -6,7 +6,7 @@
 
 <div class="mb-3">
     <label for="wpUrl" class="form-label">WordPress site URL</label>
-    <input id="wpUrl" class="form-control" @bind="userUrl" @onkeydown="HandleKeyDown" placeholder="https://example.com" />
+    <input id="wpUrl" class="form-control" @bind="userUrl" @bind:event="oninput" @onkeydown="HandleKeyDown" placeholder="https://example.com" />
 </div>
 <button class="btn btn-primary" @onclick="CheckApi">Check API</button>
 @if (!string.IsNullOrEmpty(verifiedEndpoint))


### PR DESCRIPTION
## Summary
- ensure the URL textbox updates on each keystroke

## Testing
- `dotnet build BlazorWP.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68528baf9a3c832292de80cbbabbb84e