### PR TITLE
Improve logging for request URL

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -255,7 +255,8 @@
     {
         var sb = new StringBuilder();
         var uri = request.RequestUri ?? new Uri("/", UriKind.Relative);
-        sb.Append($"{request.Method} {uri.PathAndQuery} HTTP/{request.Version.Major}.{request.Version.Minor}\r\n");
+        var requestUri = uri.IsAbsoluteUri ? uri.ToString() : uri.PathAndQuery;
+        sb.Append($"{request.Method} {requestUri} HTTP/{request.Version.Major}.{request.Version.Minor}\r\n");
 
         // Host header
         if (!request.Headers.Contains("Host") && uri.Host.Length > 0)


### PR DESCRIPTION
## Summary
- show absolute URL in raw request formatting

## Testing
- `dotnet build` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685298b3f3c48322896cdf318d48168b