### PR TITLE
Improve nested routes path handling

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -144,7 +144,8 @@ else
                 foreach (var prop in element.EnumerateObject())
                 {
                     string childPath;
-                    if (path == "routes" && prop.Name.StartsWith("/"))
+                    var isRoutes = path == "routes" || path.EndsWith("/routes");
+                    if (isRoutes && prop.Name.StartsWith("/"))
                     {
                         childPath = prop.Name;
                     }


### PR DESCRIPTION
## Summary
- handle nested `routes` objects when building API path nodes

## Testing
- `dotnet build -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68529f3ffb348322b0795cab31704775