### PR TITLE
Normalize stored API paths

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -77,14 +77,16 @@ else
             data[endpoint] = list;
         }
 
-        if (list.Contains(node.Path))
+        var normalized = NormalizePath(node.Path);
+
+        if (list.Contains(normalized))
         {
-            list.Remove(node.Path);
+            list.Remove(normalized);
             node.IsFavorite = false;
         }
         else
         {
-            list.Add(node.Path);
+            list.Add(normalized);
             node.IsFavorite = true;
         }
 
@@ -188,6 +190,36 @@ else
                 MarkFavorites(node.Children, favorites);
             }
         }
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        if (path.StartsWith("/routes/", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path["/routes".Length..];
+        }
+        else if (path.StartsWith("routes/", StringComparison.OrdinalIgnoreCase))
+        {
+            path = "/" + path["routes/".Length..];
+        }
+
+        var idx = path.IndexOf("/routes/", StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+        {
+            var prefix = path[..idx];
+            var after = path[(idx + "/routes".Length)..];
+            if (after.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                path = prefix + after[prefix.Length..];
+            }
+        }
+
+        return path;
     }
 
     public class AntJsonNode

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -137,8 +137,9 @@
                 }
                 foreach (var pair in data)
                 {
-                    foreach (var path in pair.Value)
+                    foreach (var raw in pair.Value)
                     {
+                        var path = NormalizePath(raw);
                         if (!dict.TryGetValue(path, out var set))
                         {
                             set = new HashSet<string>();
@@ -367,6 +368,7 @@
 
     private static string CombineUrl(string site, string path)
     {
+        path = NormalizePath(path);
         if (site.EndsWith("/wp-json/wp/v2", StringComparison.OrdinalIgnoreCase) &&
             path.StartsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
         {
@@ -375,6 +377,36 @@
         }
 
         return site.TrimEnd('/') + (path.StartsWith("/") ? path : "/" + path);
+    }
+
+    private static string NormalizePath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+        {
+            return path;
+        }
+
+        if (path.StartsWith("/routes/", StringComparison.OrdinalIgnoreCase))
+        {
+            path = path["/routes".Length..];
+        }
+        else if (path.StartsWith("routes/", StringComparison.OrdinalIgnoreCase))
+        {
+            path = "/" + path["routes/".Length..];
+        }
+
+        var idx = path.IndexOf("/routes/", StringComparison.OrdinalIgnoreCase);
+        if (idx >= 0)
+        {
+            var prefix = path[..idx];
+            var after = path[(idx + "/routes".Length)..];
+            if (after.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                path = prefix + after[prefix.Length..];
+            }
+        }
+
+        return path;
     }
 
     public class FavoriteEndpoint


### PR DESCRIPTION
## Summary
- normalize API paths when saving or combining URLs
- update favorite list migration logic

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045: current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6852a0e51df88322beebe85cd4b1202c