### PR TITLE
Add OAuth PKCE demo page

### DIFF
--- a/Data/PkceUtil.cs
+++ b/Data/PkceUtil.cs
@@ -1,0 +1,25 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace BlazorWP;
+
+public record PkceCodes(string CodeVerifier, string CodeChallenge);
+
+public static class PkceUtil
+{
+    public static PkceCodes Create()
+    {
+        var bytes = new byte[32];
+        RandomNumberGenerator.Fill(bytes);
+        var verifier = Base64UrlEncode(bytes);
+        using var sha = SHA256.Create();
+        var challengeBytes = sha.ComputeHash(Encoding.ASCII.GetBytes(verifier));
+        var challenge = Base64UrlEncode(challengeBytes);
+        return new PkceCodes(verifier, challenge);
+    }
+
+    private static string Base64UrlEncode(byte[] data) =>
+        Convert.ToBase64String(data).TrimEnd('=')
+            .Replace('+', '-')
+            .Replace('/', '_');
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -54,6 +54,11 @@
                 <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> Data Storage
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="oauth">
+                <span class="bi bi-key-fill-nav-menu" aria-hidden="true"></span> OAuth Demo
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/OAuth.razor
+++ b/Pages/OAuth.razor
@@ -1,0 +1,90 @@
+@page "/oauth"
+@using Microsoft.AspNetCore.WebUtilities
+@inject NavigationManager Nav
+@inject IJSRuntime JS
+@inject IConfiguration Config
+
+<!--
+  Client IDs are provided via configuration using environment variables such as
+  Authentication__Google__ClientId, Authentication__GitHub__ClientId and
+  Authentication__LINE__ClientId.
+  These map to configuration keys "Authentication:Google:ClientId" etc.
+-->
+
+<PageTitle>OAuth PKCE</PageTitle>
+
+<h1>OAuth PKCE Demo</h1>
+
+@if (!string.IsNullOrEmpty(code))
+{
+    <p>Authorization code: <code>@code</code></p>
+}
+else
+{
+    <p>Select a provider to begin OAuth login.</p>
+    <button class="btn btn-primary me-2" @onclick="() => StartOAuth(Google)">Google</button>
+    <button class="btn btn-secondary me-2" @onclick="() => StartOAuth(GitHub)">GitHub</button>
+    <button class="btn btn-success" @onclick="() => StartOAuth(Line)">LINE</button>
+}
+
+@code {
+    private string? code;
+    private OAuthProvider? Google;
+    private OAuthProvider? GitHub;
+    private OAuthProvider? Line;
+
+    protected override void OnInitialized()
+    {
+        var uri = Nav.ToAbsoluteUri(Nav.Uri);
+        var q = QueryHelpers.ParseQuery(uri.Query);
+        if (q.TryGetValue("code", out var c))
+        {
+            code = c.ToString();
+        }
+
+        Google = new OAuthProvider(
+            "https://accounts.google.com/o/oauth2/v2/auth",
+            Config["Authentication:Google:ClientId"] ?? string.Empty,
+            "openid email profile");
+
+        GitHub = new OAuthProvider(
+            "https://github.com/login/oauth/authorize",
+            Config["Authentication:GitHub:ClientId"] ?? string.Empty,
+            "read:user");
+
+        Line = new OAuthProvider(
+            "https://access.line.me/oauth2/v2.1/authorize",
+            Config["Authentication:Line:ClientId"] ?? string.Empty,
+            "profile openid");
+    }
+
+    private void StartOAuth(OAuthProvider provider)
+    {
+        var pkce = PkceUtil.Create();
+        var state = Guid.NewGuid().ToString("N");
+        var redirectUri = Nav.BaseUri.TrimEnd('/') + "/oauth";
+        var url = provider.BuildAuthorizeUrl(pkce.CodeChallenge, redirectUri, state);
+        JS.InvokeVoidAsync("sessionStorage.setItem", "pkce_" + state, pkce.CodeVerifier);
+        Nav.NavigateTo(url, true);
+    }
+
+
+    private record OAuthProvider(string AuthorizeEndpoint, string ClientId, string Scope)
+    {
+        public string BuildAuthorizeUrl(string challenge, string redirectUri, string state)
+        {
+            var query = new Dictionary<string, string?>
+            {
+                ["response_type"] = "code",
+                ["client_id"] = ClientId,
+                ["redirect_uri"] = redirectUri,
+                ["scope"] = Scope,
+                ["state"] = state,
+                ["code_challenge"] = challenge,
+                ["code_challenge_method"] = "S256"
+            };
+            var encoded = string.Join("&", query.Select(kv => $"{Uri.EscapeDataString(kv.Key)}={Uri.EscapeDataString(kv.Value!)}"));
+            return $"{AuthorizeEndpoint}?{encoded}";
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add generic PKCE helper
- create OAuth demo page implementing Google/GitHub/LINE flows
- expose new page from navigation menu
- pull OAuth client IDs from environment variables
- updated to use `Authentication:...:ClientId` keys

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685336dfeafc8322ae343228f1f3c797