### PR TITLE
Fix OAuth variable

### DIFF
--- a/Pages/OAuth.razor
+++ b/Pages/OAuth.razor
@@ -17,7 +17,7 @@
 
 @if (!string.IsNullOrEmpty(code))
 {
-    <p>Authorization code: <code>@code</code></p>
+    <p>Authorization code: <code>@(code)</code></p>
 }
 else
 {


### PR DESCRIPTION
## Summary
- avoid Razor directive misinterpretation by escaping `@code`

## Testing
- `dotnet build` *(fails: NETSDK1045 .NET 9.0 not supported with current SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68534e3ff02c832297c8b1d0e38f335c