### PR TITLE
Add OAuth client IDs to config

### DIFF
--- a/appsettings.json
+++ b/appsettings.json
@@ -1,0 +1,14 @@
+{
+  "Authentication": {
+    "Google": {
+      "ClientId": "170092734657-7hub170g0k86v1a0n4h1g5ehfp81auke.apps.googleusercontent.com"
+    },
+    "GitHub": {
+      "ClientId": "Iv23liXKevTbbJRtbx9h"
+    },
+    "Line": {
+      "ClientId": "2007382036"
+    }
+  }
+}
+


### PR DESCRIPTION
## Summary
- add Authentication client IDs to `appsettings.json`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685352db77988322a1d7929ac8876eb3