### PR TITLE
Persist JWT token

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -133,6 +133,7 @@
         {
             verifiedEndpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
             selectedSite = verifiedEndpoint;
+            jwtToken = await JS.InvokeAsync<string?>("localStorage.getItem", "jwtToken");
             await LoadFavorites();
             StateHasChanged();
         }
@@ -388,6 +389,10 @@
                     if (doc.RootElement.TryGetProperty("token", out var tokenEl))
                     {
                         jwtToken = tokenEl.GetString();
+                        if (!string.IsNullOrEmpty(jwtToken))
+                        {
+                            await JS.InvokeVoidAsync("localStorage.setItem", "jwtToken", jwtToken);
+                        }
                     }
                     else
                     {


### PR DESCRIPTION
## Summary
- store JWT token in browser localStorage when retrieved
- restore persisted JWT token on first render

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a18b8d548322ad885b574d4d1a90