### PR TITLE
Store WordPress root URL

### DIFF
--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -105,10 +105,16 @@ else
         }
 
         var rootEndpoint = endpoint;
-        if (rootEndpoint.EndsWith("/wp/v2", StringComparison.OrdinalIgnoreCase))
+        if (rootEndpoint.EndsWith("/wp-json/wp/v2", StringComparison.OrdinalIgnoreCase))
         {
-            rootEndpoint = rootEndpoint[..^"/wp/v2".Length];
+            rootEndpoint = rootEndpoint[..^"/wp-json/wp/v2".Length];
         }
+        else if (rootEndpoint.EndsWith("/wp-json", StringComparison.OrdinalIgnoreCase))
+        {
+            rootEndpoint = rootEndpoint[..^"/wp-json".Length];
+        }
+
+        rootEndpoint = rootEndpoint.TrimEnd('/') + "/wp-json";
 
         try
         {

--- a/Pages/DataStorage.razor
+++ b/Pages/DataStorage.razor
@@ -7,7 +7,7 @@
 
 <p>
     This page shows information stored in <code>localStorage</code> by this application. The
-    most important entry is <code>wpEndpoint</code> which caches the detected WordPress v2 API
+    most important entry is <code>wpEndpoint</code> which caches the detected WordPress site
     URL so you don't need to verify it each time.
 </p>
 

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -223,13 +223,13 @@
                 {
                     Path = baseUri.AbsolutePath.TrimEnd('/') + "/wp-json/wp/v2"
                 };
-                var endpoint = builder.Uri.ToString().TrimEnd('/');
+                var apiEndpoint = builder.Uri.ToString().TrimEnd('/');
 
-                logs.Add($"Requesting {endpoint}");
+                logs.Add($"Requesting {apiEndpoint}");
                 await InvokeAsync(StateHasChanged);
 
                 using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
-                var request = new HttpRequestMessage(HttpMethod.Get, endpoint);
+                var request = new HttpRequestMessage(HttpMethod.Get, apiEndpoint);
                 var rawRequest = await FormatRawRequest(request);
                 logs.Add($"-> {rawRequest}");
                 await InvokeAsync(StateHasChanged);
@@ -240,11 +240,12 @@
                 await InvokeAsync(StateHasChanged);
                 if (response.IsSuccessStatusCode)
                 {
-                    verifiedEndpoint = endpoint;
-                    selectedSite = endpoint;
-                    await JS.InvokeVoidAsync("localStorage.setItem", "wpEndpoint", verifiedEndpoint);
+                    var root = baseUri.ToString().TrimEnd('/');
+                    verifiedEndpoint = root;
+                    selectedSite = root;
+                    await JS.InvokeVoidAsync("localStorage.setItem", "wpEndpoint", root);
                     await LoadFavorites();
-                    status = $"Success! v2 endpoint is {endpoint}";
+                    status = $"Success! v2 endpoint is {apiEndpoint}";
                     return;
                 }
             }


### PR DESCRIPTION
## Summary
- persist the root site URL instead of `/wp-json/wp/v2`
- fetch API info relative to the root
- update Data Storage page text

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853a3a99e788322a06a72f2afd5a060