### PR TITLE
Initialize OAuth providers

### DIFF
--- a/Pages/OAuth.razor
+++ b/Pages/OAuth.razor
@@ -29,9 +29,9 @@ else
 
 @code {
     private string? code;
-    private OAuthProvider? Google;
-    private OAuthProvider? GitHub;
-    private OAuthProvider? Line;
+    private OAuthProvider Google = default!;
+    private OAuthProvider GitHub = default!;
+    private OAuthProvider Line = default!;
 
     protected override void OnInitialized()
     {


### PR DESCRIPTION
## Summary
- initialize nullable OAuth providers with `default!`

## Testing
- `dotnet run` *(fails: NETSDK1045, .NET 9.0 unsupported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6853ada93c5c8322a14fd1c0fc67921d