### PR TITLE
Fix nullable warnings in DecodeJwt method

### DIFF
--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -578,7 +578,7 @@
         await JS.InvokeVoidAsync("localStorage.removeItem", GetJwtTokenKey(endpoint));
     }
 
-    private static string? DecodeJwt(string token)
+    private static string? DecodeJwt(string? token)
     {
         if (string.IsNullOrWhiteSpace(token))
         {


### PR DESCRIPTION
## Summary
- make `DecodeJwt` accept nullable strings to avoid warnings when jwtToken is null

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b217e66c83228dd9a5be6fde55f0