### PR TITLE
Show current WordPress endpoint in layout

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -9,7 +9,10 @@
 
     <main>
         <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+            @if (!string.IsNullOrEmpty(currentEndpoint))
+            {
+                <span>@currentEndpoint</span>
+            }
         </div>
 
         <article class="content px-4">
@@ -17,3 +20,23 @@
         </article>
     </main>
 </div>
+
+@code {
+    [Inject]
+    private IJSRuntime JS { get; set; } = default!;
+
+    private string? currentEndpoint;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        if (endpoint != currentEndpoint)
+        {
+            currentEndpoint = endpoint;
+            if (!firstRender)
+            {
+                StateHasChanged();
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- replace the "About" link with the detected `wpEndpoint`
- load the endpoint from `localStorage` whenever the layout renders

## Testing
- `dotnet build BlazorWP.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6853dcf1e7cc8322ba3e1cda6d869307