### PR TITLE
Add endpoint selector in header

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -9,7 +9,16 @@
 
     <main>
         <div class="top-row px-4">
-            @if (!string.IsNullOrEmpty(currentEndpoint))
+            @if (endpoints.Any())
+            {
+                <select class="form-select form-select-sm" style="max-width: 20rem;" value="@currentEndpoint" @onchange="OnEndpointChanged">
+                    @foreach (var ep in endpoints)
+                    {
+                        <option value="@ep">@ep</option>
+                    }
+                </select>
+            }
+            else if (!string.IsNullOrEmpty(currentEndpoint))
             {
                 <span>@currentEndpoint</span>
             }
@@ -26,17 +35,53 @@
     private IJSRuntime JS { get; set; } = default!;
 
     private string? currentEndpoint;
+    private List<string> endpoints = new();
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
-        if (endpoint != currentEndpoint)
+
+        var json = await JS.InvokeAsync<string?>("localStorage.getItem", "siteinfo");
+        var newEndpoints = new List<string>();
+        if (!string.IsNullOrEmpty(json))
+        {
+            try
+            {
+                using var doc = JsonDocument.Parse(json);
+                foreach (var prop in doc.RootElement.EnumerateObject())
+                {
+                    newEndpoints.Add(prop.Name);
+                }
+            }
+            catch
+            {
+                // ignore malformed data
+            }
+        }
+
+        bool changed = !newEndpoints.SequenceEqual(endpoints);
+        if (changed)
+        {
+            endpoints = newEndpoints;
+        }
+
+        if (endpoint != currentEndpoint || changed)
         {
             currentEndpoint = endpoint;
             if (!firstRender)
             {
                 StateHasChanged();
             }
+        }
+    }
+
+    private async Task OnEndpointChanged(ChangeEventArgs e)
+    {
+        var value = e.Value?.ToString();
+        if (!string.IsNullOrEmpty(value))
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "wpEndpoint", value);
+            currentEndpoint = value;
         }
     }
 }

--- a/Layout/MainLayout.razor.css
+++ b/Layout/MainLayout.razor.css
@@ -27,6 +27,11 @@ main {
         text-decoration: none;
     }
 
+    .top-row select {
+        margin-left: 1.5rem;
+        max-width: 20rem;
+    }
+
     .top-row ::deep a:hover, .top-row ::deep .btn-link:hover {
         text-decoration: underline;
     }


### PR DESCRIPTION
## Summary
- show a drop-down of available WordPress endpoints
- read `siteinfo` from localStorage
- update selected endpoint in localStorage

## Testing
- `dotnet build BlazorWP.csproj -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853dfc66fec8322b5242db2c9f945cb