### PR TITLE
Ensure wpEndpoint display stays in sync

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -1,5 +1,7 @@
 @inherits LayoutComponentBase
 
+@implements IAsyncDisposable
+
 <MudPopoverProvider />
 
 <div class="page">
@@ -26,6 +28,7 @@
     private IJSRuntime JS { get; set; } = default!;
 
     private string? currentEndpoint;
+    private DotNetObjectReference<MainLayout>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -33,10 +36,32 @@
         if (endpoint != currentEndpoint)
         {
             currentEndpoint = endpoint;
-            if (!firstRender)
-            {
-                StateHasChanged();
-            }
+            StateHasChanged();
+        }
+
+        if (firstRender)
+        {
+            _objRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("wpEndpointSync.register", _objRef);
+        }
+    }
+
+    [JSInvokable]
+    public void UpdateEndpoint(string? endpoint)
+    {
+        if (endpoint != currentEndpoint)
+        {
+            currentEndpoint = endpoint;
+            InvokeAsync(StateHasChanged);
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_objRef != null)
+        {
+            await JS.InvokeVoidAsync("wpEndpointSync.unregister");
+            _objRef.Dispose();
         }
     }
 }

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -332,7 +332,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                     var root = baseUri.ToString().TrimEnd('/');
                     verifiedEndpoint = root;
                     userUrl = root;
-                    await JS.InvokeVoidAsync("localStorage.setItem", "wpEndpoint", root);
+                    await JS.InvokeVoidAsync("wpEndpointSync.set", root);
 
                     var siteInfo = await LoadSiteInfoAsync();
                     if (!siteInfo.ContainsKey(root))

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -39,6 +39,7 @@
     <script src="js/pdTreeHighlight.js"></script>
     <script src="js/pdTreeToggle.js"></script>
     <script src="js/storageUtils.js"></script>
+    <script src="js/wpEndpointSync.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/wpEndpointSync.js
+++ b/wwwroot/js/wpEndpointSync.js
@@ -1,0 +1,25 @@
+window.wpEndpointSync = (function () {
+  let dotNetHelper = null;
+  function handleStorage(e) {
+    if (e.key === 'wpEndpoint' && dotNetHelper) {
+      dotNetHelper.invokeMethodAsync('UpdateEndpoint', e.newValue);
+    }
+  }
+  return {
+    register: function (dotnet) {
+      dotNetHelper = dotnet;
+      window.addEventListener('storage', handleStorage);
+      dotnet.invokeMethodAsync('UpdateEndpoint', localStorage.getItem('wpEndpoint'));
+    },
+    unregister: function () {
+      window.removeEventListener('storage', handleStorage);
+      dotNetHelper = null;
+    },
+    set: function (value) {
+      localStorage.setItem('wpEndpoint', value);
+      if (dotNetHelper) {
+        dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
+      }
+    }
+  };
+})();


### PR DESCRIPTION
## Summary
- watch localStorage for changes to `wpEndpoint`
- update the layout's displayed endpoint whenever `wpEndpoint` changes
- call new JS helper instead of `localStorage.setItem`
- include new script in the site HTML

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853e5c2c7348322a1b0e628909352ab