### PR TITLE
Add JWT authorization to API requests

### DIFF
--- a/Data/JwtAuthMessageHandler.cs
+++ b/Data/JwtAuthMessageHandler.cs
@@ -1,0 +1,25 @@
+using System.Net.Http.Headers;
+
+namespace BlazorWP;
+
+public class JwtAuthMessageHandler : DelegatingHandler
+{
+    private readonly JwtService _jwtService;
+
+    public JwtAuthMessageHandler(JwtService jwtService)
+    {
+        _jwtService = jwtService;
+        InnerHandler = new HttpClientHandler();
+    }
+
+    protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        var token = await _jwtService.GetCurrentJwtAsync();
+        if (!string.IsNullOrWhiteSpace(token))
+        {
+            request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        }
+
+        return await base.SendAsync(request, cancellationToken);
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -17,8 +17,12 @@ namespace BlazorWP
             builder.RootComponents.Add<HeadOutlet>("head::after");
 
             // 3) Your services
+            builder.Services.AddScoped<JwtAuthMessageHandler>();
             builder.Services.AddScoped(sp =>
-                new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+            {
+                var handler = sp.GetRequiredService<JwtAuthMessageHandler>();
+                return new HttpClient(handler) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) };
+            });
             builder.Services.AddMudServices();
             builder.Services.AddPanoramicDataBlazor();
             builder.Services.AddAntDesign();


### PR DESCRIPTION
## Summary
- add `JwtAuthMessageHandler` to attach JWT token to outgoing requests
- register the handler in `Program.cs`

## Testing
- `dotnet build -v minimal` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853ec748d208322afa9cbdba68333ca