### PR TITLE
Switch editor to use JsConfSrc

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -127,20 +127,11 @@
 
 
 <Editor
-ScriptSrc="libman/tinymce/tinymce.min.js"
-  LicenseKey="gpl"
-  @bind-Value="_content"
-  Conf="@_editorConfig" />
-@code {
-  private string _content = "<p>Hello, world!</p>";
+    ScriptSrc="libman/tinymce/tinymce.min.js"
+    LicenseKey="gpl"
+    @bind-Value="_content"
+    JsConfSrc="myTinyMceConfig" />
 
-  private readonly Dictionary<string, object> _editorConfig = new()
-  {
-    // disable the “Get all features” promo button
-    { "promotion", false },
-    // hide the “Build with TinyMCE” / “Powered by Tiny” link
-    { "branding",   false },
-    // (optional) remove the entire status bar
-    { "statusbar",  false }
-  };
+@code {
+    private string _content = "<p>Hello, world!</p>";
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -41,6 +41,7 @@
     <script src="js/pdTreeToggle.js"></script>
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
+    <script src="js/tinyMceConfig.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -1,0 +1,14 @@
+window.myTinyMceConfig = {
+  promotion: false,
+  branding: false,
+  statusbar: false,
+  toolbar: 'undo redo | bold italic | customButton',
+  setup: function (editor) {
+    editor.ui.registry.addButton('customButton', {
+      text: 'Alert',
+      onAction: function () {
+        alert('Hello from TinyMCE!');
+      }
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add TinyMCE config in `wwwroot/js/tinyMceConfig.js`
- load `tinyMceConfig.js` in `wwwroot/index.html`
- use `JsConfSrc` in `Edit.razor` to reference the config

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685666dc5a60832290eab03bb1c16d66