### PR TITLE
Add info button to TinyMCE

### DIFF
--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -2,12 +2,20 @@ window.myTinyMceConfig = {
   promotion: false,
   branding: false,
   statusbar: false,
-  toolbar: 'undo redo | bold italic | customButton',
+  toolbar: 'undo redo | bold italic | customButton showInfoButton',
   setup: function (editor) {
     editor.ui.registry.addButton('customButton', {
       text: 'Alert',
       onAction: function () {
         alert('Hello from TinyMCE!');
+      }
+    });
+    editor.ui.registry.addButton('showInfoButton', {
+      text: 'Info',
+      onAction: function () {
+        const endpoint = localStorage.getItem('wpEndpoint') || '(none)';
+        const token = localStorage.getItem('jwtToken') || '(none)';
+        alert(`Endpoint: ${endpoint}\nJWT: ${token}`);
       }
     });
   }


### PR DESCRIPTION
## Summary
- extend tinyMCE toolbar config
- add new button that shows `wpEndpoint` and `jwtToken`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68566bb79e1483228febc190dc3c8499