### PR TITLE
Fix JWT handler path check

### DIFF
--- a/Data/JwtAuthMessageHandler.cs
+++ b/Data/JwtAuthMessageHandler.cs
@@ -21,7 +21,8 @@ public class JwtAuthMessageHandler : DelegatingHandler
         }
         var path = uri.AbsolutePath.TrimEnd('/');
         return path.EndsWith("/wp-json/wp/v2", StringComparison.OrdinalIgnoreCase)
-            || path.EndsWith("/wp-json/jwt-auth/v1/token", StringComparison.OrdinalIgnoreCase);
+            || path.EndsWith("/wp-json/jwt-auth/v1/token", StringComparison.OrdinalIgnoreCase)
+            || path.EndsWith("/jwt-auth/v1/token", StringComparison.OrdinalIgnoreCase);
     }
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)


### PR DESCRIPTION
## Summary
- add `/jwt-auth/v1/token` to skip list for JWT header

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 - current .NET SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685670293950832290a4fef3988bce70