### PR TITLE
Show JWT token in editor page

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -2,6 +2,7 @@
 @using TinyMCE.Blazor
 @inject HttpClient Http
 @inject IJSRuntime JS
+@inject JwtService JwtService
 
 <PageTitle>Edit</PageTitle>
 
@@ -16,14 +17,27 @@
     <label class="form-label" for="postTitle">Title</label>
     <input id="postTitle" class="form-control" @bind="postTitle" />
 </div>
-<button class="btn btn-primary" @onclick="CreatePost">Add Post</button>
+<div class="d-flex align-items-center mb-2">
+    <button class="btn btn-primary" @onclick="CreatePost">Add Post</button>
+    @if (!string.IsNullOrEmpty(jwtToken))
+    {
+        <span class="ms-2 small"><code>@jwtToken</code></span>
+    }
+</div>
 
 @code {
     private string? status;
     private string postTitle = string.Empty;
+    private string? jwtToken;
+
+    protected override async Task OnInitializedAsync()
+    {
+        jwtToken = await JwtService.GetCurrentJwtAsync();
+    }
 
     private async Task CreatePost()
     {
+        jwtToken = await JwtService.GetCurrentJwtAsync();
         var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
         if (string.IsNullOrEmpty(endpoint))
         {


### PR DESCRIPTION
## Summary
- inject `JwtService` on the editor page
- display the current JWT next to **Add Post** button for easier debugging
- refresh JWT on initialization and when posting

## Testing
- `dotnet build --nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685672fa51cc8322acf8d0d9870ab053