### PR TITLE
Fix TinyMCE JWT info button

### DIFF
--- a/Data/JwtService.cs
+++ b/Data/JwtService.cs
@@ -104,6 +104,17 @@ public class JwtService
         }
 
         var info = await LoadJwtInfoAsync(endpoint);
-        return info?.Token;
+        var token = info?.Token;
+
+        if (!string.IsNullOrEmpty(token))
+        {
+            await _js.InvokeVoidAsync("localStorage.setItem", "jwtToken", token);
+        }
+        else
+        {
+            await _js.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+        }
+
+        return token;
     }
 }

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -348,11 +348,20 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                         jwtUsername = info.Username;
                         jwtPassword = info.Password;
                         jwtDecoded = DecodeJwt(jwtToken);
+                        if (!string.IsNullOrEmpty(jwtToken))
+                        {
+                            await JS.InvokeVoidAsync("localStorage.setItem", "jwtToken", jwtToken);
+                        }
+                        else
+                        {
+                            await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+                        }
                     }
                     else
                     {
                         jwtToken = null;
                         jwtDecoded = null;
+                        await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
                     }
                     await LoadFavorites();
                     status = $"Success! v2 endpoint is {apiEndpoint}";
@@ -668,6 +677,15 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
         var data = await LoadSiteInfoAsync();
         data[endpoint] = info;
         await SaveSiteInfoAsync(data);
+
+        if (!string.IsNullOrEmpty(info.Token))
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "jwtToken", info.Token);
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+        }
 
         var oldKey = GetOldJwtInfoKey(endpoint);
         await JS.InvokeVoidAsync("localStorage.removeItem", oldKey);


### PR DESCRIPTION
## Summary
- sync JWT token to `localStorage['jwtToken']` whenever it is saved or loaded
- propagate token in `CheckApi` and `JwtService` so TinyMCE can read it

## Testing
- `dotnet build BlazorWP.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856775f5ffc832287d0509b21a8e1f5