### PR TITLE
Add media library dialog for TinyMCE

### DIFF
--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -2,7 +2,7 @@ window.myTinyMceConfig = {
   promotion: false,
   branding: false,
   statusbar: false,
-  toolbar: 'undo redo | bold italic | customButton showInfoButton',
+  toolbar: 'undo redo | bold italic | customButton showInfoButton mediaLibraryButton',
   setup: function (editor) {
     editor.ui.registry.addButton('customButton', {
       text: 'Alert',
@@ -16,6 +16,66 @@ window.myTinyMceConfig = {
         const endpoint = localStorage.getItem('wpEndpoint') || '(none)';
         const token = localStorage.getItem('jwtToken') || '(none)';
         alert(`Endpoint: ${endpoint}\nJWT: ${token}`);
+      }
+    });
+
+    function openMediaDialog(items) {
+      const images = items.map(i => {
+        const thumb = (i.media_details && i.media_details.sizes && i.media_details.sizes.thumbnail)
+          ? i.media_details.sizes.thumbnail.source_url
+          : i.source_url;
+        return `<img src="${thumb}" data-full="${i.source_url}" style="width:100px;height:100px;object-fit:cover;margin:4px;cursor:pointer;" />`;
+      }).join('');
+
+      const html = `<div style="display:flex;flex-wrap:wrap;">${images}</div>`;
+
+      const dlg = editor.windowManager.open({
+        title: 'Media Library',
+        size: 'large',
+        body: {
+          type: 'panel',
+          items: [{ type: 'htmlpanel', html: html }]
+        },
+        buttons: []
+      });
+
+      const panel = dlg.getEl().querySelector('div');
+      panel.addEventListener('click', function (e) {
+        if (e.target.tagName === 'IMG') {
+          const url = e.target.getAttribute('data-full');
+          editor.insertContent(`<img src="${url}" />`);
+          dlg.close();
+        }
+      });
+    }
+
+    async function fetchMedia() {
+      const endpoint = localStorage.getItem('wpEndpoint');
+      const token = localStorage.getItem('jwtToken');
+      if (!endpoint) {
+        alert('No WordPress endpoint configured.');
+        return;
+      }
+      const url = endpoint.replace(/\/?$/, '') + '/wp-json/wp/v2/media?per_page=100';
+      try {
+        const res = await fetch(url, {
+          headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+        });
+        if (!res.ok) {
+          alert('Failed to load media: ' + res.status);
+          return;
+        }
+        const data = await res.json();
+        openMediaDialog(data);
+      } catch (err) {
+        alert('Error loading media: ' + err);
+      }
+    }
+
+    editor.ui.registry.addButton('mediaLibraryButton', {
+      text: 'Media',
+      onAction: function () {
+        fetchMedia();
       }
     });
   }


### PR DESCRIPTION
## Summary
- add `mediaLibraryButton` to TinyMCE toolbar
- fetch media items via WordPress REST API using stored JWT
- show a dialog of images and insert selected image into the editor

## Testing
- `dotnet build BlazorWP.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856795cd3b08322a34eae3b6f7cec84