### PR TITLE
Fix editor media endpoint

### DIFF
--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -49,14 +49,11 @@ window.myTinyMceConfig = {
       });
     }
 
+    const mediaSource = 'https://workers-coop.com/honbu/kanagawa';
+
     async function fetchMedia() {
-      const endpoint = localStorage.getItem('wpEndpoint');
       const token = localStorage.getItem('jwtToken');
-      if (!endpoint) {
-        alert('No WordPress endpoint configured.');
-        return;
-      }
-      const url = endpoint.replace(/\/?$/, '') + '/wp-json/wp/v2/media?per_page=100';
+      const url = mediaSource.replace(/\/?$/, '') + '/wp-json/wp/v2/media?per_page=100';
       try {
         const res = await fetch(url, {
           headers: token ? { 'Authorization': 'Bearer ' + token } : {}


### PR DESCRIPTION
## Summary
- use a fixed media URL in TinyMCE config for the editor

## Testing
- `dotnet build -v minimal` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6856a1f8ffec83229a7cede01597143a