### PR TITLE
Enable TinyMCE resizing

### DIFF
--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -1,7 +1,8 @@
 window.myTinyMceConfig = {
   promotion: false,
   branding: false,
-  statusbar: false,
+  statusbar: true,
+  resize: 'both',
   plugins: 'code media',
   toolbar: 'undo redo | bold italic | code mediaLibraryButton customButton showInfoButton',
   setup: function (editor) {


### PR DESCRIPTION
## Summary
- update tinyMCE config to re-enable status bar
- allow resizing of the editor window

## Testing
- `dotnet build BlazorWP.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68571b7caf348322b8f1ae9b649b1167