### PR TITLE
Enable configurable media source on Edit page

### DIFF
--- a/Data/JwtService.cs
+++ b/Data/JwtService.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.JSInterop;
+using System.Linq;
 
 namespace BlazorWP;
 
@@ -40,6 +41,12 @@ public class JwtService
         {
             return new();
         }
+    }
+
+    public async Task<List<string>> GetSiteInfoKeysAsync()
+    {
+        var data = await LoadSiteInfoAsync();
+        return data.Keys.OrderBy(k => k).ToList();
     }
 
     private Task SaveSiteInfoAsync(Dictionary<string, JwtInfo> data)

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -18,29 +18,48 @@
     <label class="form-label" for="postTitle">Title</label>
     <input id="postTitle" class="form-control" @bind="postTitle" />
 </div>
+@if (mediaSources.Any())
+{
+    <div class="mb-3">
+        <label class="form-label" for="mediaSource">Media Source</label>
+        <select id="mediaSource" class="form-select" @bind="selectedMediaSource" @onchange="OnMediaSourceChanged">
+            <option value="">-- choose media site --</option>
+            @foreach (var site in mediaSources)
+            {
+                <option value="@site">@site</option>
+            }
+        </select>
+    </div>
+}
+
 <div class="d-flex align-items-center mb-2">
     <button class="btn btn-primary" @onclick="SaveDraft">Save Draft</button>
-    @if (!string.IsNullOrEmpty(jwtToken))
-    {
-        <span class="ms-2 small"><code>@jwtToken</code></span>
-    }
 </div>
 
 @code {
     private string? status;
     private string postTitle = string.Empty;
-    private string? jwtToken;
+    private List<string> mediaSources = new();
+    private string? selectedMediaSource;
 
-    protected override async Task OnInitializedAsync()
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        jwtToken = await JwtService.GetCurrentJwtAsync();
+        if (firstRender)
+        {
+            mediaSources = await JwtService.GetSiteInfoKeysAsync();
+            selectedMediaSource = await JS.InvokeAsync<string?>("localStorage.getItem", "mediaSource");
+            if (!string.IsNullOrEmpty(selectedMediaSource))
+            {
+                await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
+            }
+            StateHasChanged();
+        }
     }
 
     private int? postId;
 
     private async Task SaveDraft()
     {
-        jwtToken = await JwtService.GetCurrentJwtAsync();
         var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
         if (string.IsNullOrEmpty(endpoint))
         {
@@ -96,6 +115,20 @@
         {
             status = $"Error: {ex.Message}";
         }
+    }
+
+    private async Task OnMediaSourceChanged(ChangeEventArgs e)
+    {
+        selectedMediaSource = e.Value?.ToString();
+        if (string.IsNullOrEmpty(selectedMediaSource))
+        {
+            await JS.InvokeVoidAsync("localStorage.removeItem", "mediaSource");
+        }
+        else
+        {
+            await JS.InvokeVoidAsync("localStorage.setItem", "mediaSource", selectedMediaSource);
+        }
+        await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
     }
 
     private static string CombineUrl(string site, string path)

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -5,6 +5,7 @@ window.myTinyMceConfig = {
   resize: 'both',
   plugins: 'code media',
   toolbar: 'undo redo | bold italic | code mediaLibraryButton customButton showInfoButton',
+  mediaSource: null,
   setup: function (editor) {
     editor.ui.registry.addButton('customButton', {
       text: 'Alert',
@@ -70,11 +71,18 @@ window.myTinyMceConfig = {
       });
     }
 
-    const mediaSource = 'https://workers-coop.com/honbu/kanagawa';
+    function getMediaSource() {
+      return window.myTinyMceConfig.mediaSource;
+    }
 
     async function fetchMedia(page = 1) {
+      const source = getMediaSource();
+      if (!source) {
+        alert('No media source selected');
+        return { items: [], totalPages: page };
+      }
       const token = localStorage.getItem('jwtToken');
-      const url = mediaSource.replace(/\/?$/, '') + `/wp-json/wp/v2/media?per_page=100&page=${page}`;
+      const url = source.replace(/\/?$/, '') + `/wp-json/wp/v2/media?per_page=100&page=${page}`;
       try {
         const res = await fetch(url, {
           headers: token ? { 'Authorization': 'Bearer ' + token } : {}
@@ -100,4 +108,8 @@ window.myTinyMceConfig = {
       }
     });
   }
+};
+
+window.setTinyMediaSource = function (url) {
+  window.myTinyMceConfig.mediaSource = url || null;
 };


### PR DESCRIPTION
## Summary
- remove JWT token display on the Edit page
- allow picking a media source using the saved site info
- add helper to load siteinfo keys
- make TinyMCE media source configurable via JavaScript

## Testing
- `dotnet build -v q` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857227b31048322bf2f3aaca56926a5