### PR TITLE
Fix duplicate onchange attribute in Edit page

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -22,7 +22,7 @@
 {
     <div class="mb-3">
         <label class="form-label" for="mediaSource">Media Source</label>
-        <select id="mediaSource" class="form-select" @bind="selectedMediaSource" @onchange="OnMediaSourceChanged">
+        <select id="mediaSource" class="form-select" value="@selectedMediaSource" @onchange="OnMediaSourceChanged">
             <option value="">-- choose media site --</option>
             @foreach (var site in mediaSources)
             {


### PR DESCRIPTION
## Summary
- clean up Edit page to avoid duplicate `onchange` attribute

## Testing
- `dotnet run` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685723e930b48322ada525526ee00793