### PR TITLE
Show current article first

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -41,10 +41,6 @@
 {
     <p><em>Loading posts...</em></p>
 }
-else if (posts.Count == 0)
-{
-    <p>No posts found.</p>
-}
 else
 {
     <table class="table">
@@ -55,10 +51,10 @@ else
             </tr>
         </thead>
         <tbody>
-            @foreach (var p in posts)
+            @foreach (var p in DisplayPosts)
             {
                 <tr>
-                    <td>@p.Id</td>
+                    <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
                     <td>@p.Title</td>
                 </tr>
             }
@@ -74,6 +70,48 @@ else
     private List<string> mediaSources = new();
     private string? selectedMediaSource;
     private List<PostSummary>? posts;
+
+    private IEnumerable<PostSummary> DisplayPosts
+    {
+        get
+        {
+            var list = new List<PostSummary>();
+
+            if (postId == null)
+            {
+                var title = string.IsNullOrWhiteSpace(postTitle)
+                    ? "(Not saved yet)"
+                    : $"{postTitle} (not saved yet)";
+                list.Add(new PostSummary { Id = -1, Title = title });
+            }
+            else if (posts != null)
+            {
+                var current = posts.FirstOrDefault(p => p.Id == postId);
+                if (current != null)
+                {
+                    list.Add(current);
+                }
+            }
+
+            if (posts != null)
+            {
+                foreach (var p in posts)
+                {
+                    if (postId != null && p.Id == postId)
+                    {
+                        continue;
+                    }
+                    if (list.Count >= 3)
+                    {
+                        break;
+                    }
+                    list.Add(p);
+                }
+            }
+
+            return list.Take(3);
+        }
+    }
 
     private class DraftInfo
     {


### PR DESCRIPTION
## Summary
- keep the current editing post at the top of the list
- show "not saved yet" when the post has not been saved
- cap the display list to 3 items

## Testing
- `dotnet build -v:m` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857611ae4cc832285789b2eafe9f4fd