### PR TITLE
Add TinyMCE wrapper component

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -1,0 +1,27 @@
+@using TinyMCE.Blazor
+<div class="tiny-editor-wrapper">
+    <Editor 
+        ScriptSrc="libman/tinymce/tinymce.min.js" 
+        LicenseKey="gpl"
+        JsConfSrc="myTinyMceConfig"
+        Value="@Value" 
+        ValueChanged="@OnEditorValueChanged" />
+</div>
+
+@code {
+    [Parameter]
+    public string Value { get; set; } = string.Empty;
+
+    [Parameter]
+    public EventCallback<string> ValueChanged { get; set; }
+
+    [Parameter]
+    public EventCallback<string> OnContentChanged { get; set; }
+
+    private async Task OnEditorValueChanged(string newValue)
+    {
+        Value = newValue;
+        await ValueChanged.InvokeAsync(newValue);
+        await OnContentChanged.InvokeAsync(newValue);
+    }
+}

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -456,12 +456,7 @@ else
 
 
 
-<Editor
-    ScriptSrc="libman/tinymce/tinymce.min.js"
-    LicenseKey="gpl"
-    @bind-Value="_content"
-    ValueChanged="ContentChanged"
-    JsConfSrc="myTinyMceConfig" />
+<TinyMCEEditor @bind-Value="_content" OnContentChanged="ContentChanged" />
 
 @code {
     private string _content = "<p>Hello, world!</p>";

--- a/_Imports.razor
+++ b/_Imports.razor
@@ -9,6 +9,7 @@
 @using Microsoft.JSInterop
 @using BlazorWP
 @using BlazorWP.Layout
+@using BlazorWP.Components
 @using System.Linq
 @using System.Text
 @using System.Text.Json


### PR DESCRIPTION
## Summary
- create `TinyMCEEditor` component wrapping TinyMCE.Blazor `Editor`
- import new component namespace
- use new `TinyMCEEditor` in `Edit.razor`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68576fd8bb908322abe67fcf010e87bc