### PR TITLE
Fix retract review visibility after refresh

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -375,7 +375,7 @@ else
             return;
         }
 
-        var url = CombineUrl(endpoint, "/wp/v2/posts");
+        var url = CombineUrl(endpoint, "/wp/v2/posts?context=edit&status=any");
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
## Summary
- show pending posts by requesting all statuses when loading posts

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857754d0af48322909ae813b2521b67