### PR TITLE
Add editor close button

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -1,10 +1,11 @@
 @using TinyMCE.Blazor
-<div class="tiny-editor-wrapper">
-    <Editor 
-        ScriptSrc="libman/tinymce/tinymce.min.js" 
+<div class="tiny-editor-wrapper position-relative">
+    <button type="button" class="btn-close position-absolute end-0" aria-label="Close" @onclick="CloseEditor"></button>
+    <Editor
+        ScriptSrc="libman/tinymce/tinymce.min.js"
         LicenseKey="gpl"
         JsConfSrc="myTinyMceConfig"
-        Value="@Value" 
+        Value="@Value"
         ValueChanged="@OnEditorValueChanged" />
 </div>
 
@@ -18,10 +19,18 @@
     [Parameter]
     public EventCallback<string> OnContentChanged { get; set; }
 
+    [Parameter]
+    public EventCallback OnClose { get; set; }
+
     private async Task OnEditorValueChanged(string newValue)
     {
         Value = newValue;
         await ValueChanged.InvokeAsync(newValue);
         await OnContentChanged.InvokeAsync(newValue);
+    }
+
+    private async Task CloseEditor()
+    {
+        await OnClose.InvokeAsync();
     }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -503,8 +503,17 @@ else
 
 
 
-<TinyMCEEditor @bind-Value="_content" OnContentChanged="ContentChanged" />
+@if (showEditor)
+{
+    <TinyMCEEditor @bind-Value="_content" OnContentChanged="ContentChanged" OnClose="CloseEditor" />
+}
 
 @code {
     private string _content = "<p>Hello, world!</p>";
+    private bool showEditor = true;
+
+    private void CloseEditor()
+    {
+        showEditor = false;
+    }
 }


### PR DESCRIPTION
## Summary
- allow the TinyMCE editor component to emit a close event
- show/hide the editor on the edit page with a close button

## Testing
- `dotnet --info` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685777d94dc08322a2112e1d924785e9