### PR TITLE
Display author name

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -67,7 +67,7 @@ else
                     <tr>
                         <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
                         <td>@p.Title</td>
-                        <td>@(p.Author > 0 ? p.Author.ToString() : "")</td>
+                    <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
                         <td>@(p.Status == "pending" ? "Pending" : "")</td>
                     </tr>
                 }


### PR DESCRIPTION
## Summary
- show post author's name instead of numeric id
- request embedded author info when retrieving posts

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68578df574dc8322be06c507cdba6f48