### PR TITLE
Add article status management

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -59,6 +59,10 @@ else
                     <th>Title</th>
                     <th>Author</th>
                     <th>Status</th>
+                    @if (canChangeStatus)
+                    {
+                        <th>Change Status</th>
+                    }
                 </tr>
             </thead>
             <tbody>
@@ -68,7 +72,16 @@ else
                         <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
                         <td>@p.Title</td>
                     <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
-                        <td>@(p.Status == "pending" ? "Pending" : "")</td>
+                        <td>@p.Status</td>
+                        @if (canChangeStatus)
+                        {
+                            <td>
+                                @foreach (var st in availableStatuses)
+                                {
+                                    <button class="btn btn-sm me-1 @(p.Status == st ? "btn-primary" : "btn-outline-secondary")" @onclick="() => ChangeStatus(p, st)">@st</button>
+                                }
+                            </td>
+                        }
                     </tr>
                 }
             </tbody>


### PR DESCRIPTION
## Summary
- add `GetCurrentUserRolesAsync` to decode JWT roles
- enable editors and admins to change status in the editor
- show buttons for all statuses

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685792be3d788322bcb8ca9ba00bbf9f