### PR TITLE
Expose status update controls in article table

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -59,10 +59,7 @@ else
                     <th>Title</th>
                     <th>Author</th>
                     <th>Status</th>
-                    @if (canChangeStatus)
-                    {
-                        <th>Change Status</th>
-                    }
+                    <th>Change Status</th>
                 </tr>
             </thead>
             <tbody>
@@ -73,15 +70,12 @@ else
                         <td>@p.Title</td>
                     <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
                         <td>@p.Status</td>
-                        @if (canChangeStatus)
-                        {
-                            <td>
-                                @foreach (var st in availableStatuses)
-                                {
-                                    <button class="btn btn-sm me-1 @(p.Status == st ? "btn-primary" : "btn-outline-secondary")" @onclick="() => ChangeStatus(p, st)">@st</button>
-                                }
-                            </td>
-                        }
+                        <td>
+                            @foreach (var st in availableStatuses)
+                            {
+                                <button class="btn btn-sm me-1 @(p.Status == st ? "btn-primary" : "btn-outline-secondary")" @onclick="() => ChangeStatus(p, st)">@st</button>
+                            }
+                        </td>
                     </tr>
                 }
             </tbody>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -22,7 +22,6 @@ public partial class Edit : IAsyncDisposable
     private int currentPage = 1;
     private bool isLoading = false;
     private string _content = "<p>Hello, world!</p>";
-    private bool canChangeStatus = false;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private" };
 
     private IEnumerable<PostSummary> DisplayPosts
@@ -103,7 +102,6 @@ public partial class Edit : IAsyncDisposable
         hasMore = true;
         await LoadPosts(currentPage);
         UpdateDirty();
-        await LoadUserRoles();
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -116,7 +114,6 @@ public partial class Edit : IAsyncDisposable
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
-            await LoadUserRoles();
             StateHasChanged();
         }
 
@@ -455,13 +452,6 @@ public partial class Edit : IAsyncDisposable
         }
     }
 
-    private async Task LoadUserRoles()
-    {
-        var roles = await JwtService.GetCurrentUserRolesAsync();
-        canChangeStatus = roles.Any(r =>
-            string.Equals(r, "administrator", StringComparison.OrdinalIgnoreCase) ||
-            string.Equals(r, "editor", StringComparison.OrdinalIgnoreCase));
-    }
 
     private static string CombineUrl(string site, string path)
     {


### PR DESCRIPTION
## Summary
- simplify permission logic
- always show change status column in article list

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685794f65f488322a4bdbe3f097dd508