### PR TITLE
Fix dropdown navigation bug

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -79,7 +79,7 @@ else
                                     @foreach (var st in availableStatuses)
                                     {
                                         <li>
-                                            <a class="dropdown-item @(p.Status == st ? "active" : null)" href="#" @onclick="() => ChangeStatus(p, st)">@st</a>
+                                            <button type="button" class="dropdown-item @(p.Status == st ? "active" : null)" @onclick="() => ChangeStatus(p, st)">@st</button>
                                         </li>
                                     }
                                 </ul>


### PR DESCRIPTION
## Summary
- ensure status dropdown doesn't trigger page navigation

## Testing
- `dotnet build --no-restore` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685798a00c2c832284aa49eb9a24ff9d