### PR TITLE
Improve status button handling in Edit page

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -71,19 +71,22 @@ else
                     <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
                         <td>@p.Status</td>
                         <td>
-                            <div class="dropdown">
-                                <button class="btn btn-sm btn-outline-secondary dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
-                                    @p.Status
-                                </button>
-                                <ul class="dropdown-menu">
-                                    @foreach (var st in availableStatuses)
-                                    {
-                                        <li>
-                                            <button type="button" class="dropdown-item @(p.Status == st ? "active" : null)" @onclick="() => ChangeStatus(p, st)">@st</button>
-                                        </li>
-                                    }
-                                </ul>
-                            </div>
+                            @if (p.Id > 0 && !string.IsNullOrEmpty(p.Status))
+                            {
+                                <div class="dropdown">
+                                    <button class="btn btn-sm @(GetStatusButtonClass(p.Status)) dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+                                        @p.Status
+                                    </button>
+                                    <ul class="dropdown-menu">
+                                        @foreach (var st in availableStatuses)
+                                        {
+                                            <li>
+                                                <button type="button" class="dropdown-item @(p.Status == st ? "active" : null)" @onclick="() => ChangeStatus(p, st)">@st</button>
+                                            </li>
+                                        }
+                                    </ul>
+                                </div>
+                            }
                         </td>
                     </tr>
                 }

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -452,6 +452,18 @@ public partial class Edit : IAsyncDisposable
         }
     }
 
+    private static string GetStatusButtonClass(string? status)
+    {
+        return status switch
+        {
+            "draft" => "btn-outline-secondary",
+            "pending" => "btn-outline-warning",
+            "publish" => "btn-outline-success",
+            "private" => "btn-outline-dark",
+            _ => "btn-outline-secondary",
+        };
+    }
+
 
     private static string CombineUrl(string site, string path)
     {


### PR DESCRIPTION
## Summary
- hide status dropdown for unsaved posts
- color status dropdown button based on post status

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68579ae3e4b883229cd083c1310d64c9