### PR TITLE
Add collapsible editor sections and fullscreen support

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -11,45 +11,53 @@
 
 <h1>Edit</h1>
 
-@if (!string.IsNullOrEmpty(status))
-{
-    <p>@status</p>
-}
-
-<div class="mb-3">
-    <label class="form-label" for="postTitle">Title</label>
-    <input id="postTitle" class="form-control" @bind="postTitle" @oninput="TitleInput" />
+<div class="mb-2">
+    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleControls">@(showControls ? "Hide Details" : "Show Details")</button>
+    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="ToggleTable">@(showTable ? "Hide Posts" : "Show Posts")</button>
 </div>
-@if (mediaSources.Any())
+
+@if (showControls)
 {
+    @if (!string.IsNullOrEmpty(status))
+    {
+        <p>@status</p>
+    }
+
     <div class="mb-3">
-        <label class="form-label" for="mediaSource">Media Source</label>
-        <select id="mediaSource" class="form-select" value="@selectedMediaSource" @onchange="OnMediaSourceChanged">
-            <option value="">-- choose media site --</option>
-            @foreach (var site in mediaSources)
-            {
-                <option value="@site">@site</option>
-            }
-        </select>
+        <label class="form-label" for="postTitle">Title</label>
+        <input id="postTitle" class="form-control" @bind="postTitle" @oninput="TitleInput" />
+    </div>
+    @if (mediaSources.Any())
+    {
+        <div class="mb-3">
+            <label class="form-label" for="mediaSource">Media Source</label>
+            <select id="mediaSource" class="form-select" value="@selectedMediaSource" @onchange="OnMediaSourceChanged">
+                <option value="">-- choose media site --</option>
+                @foreach (var site in mediaSources)
+                {
+                    <option value="@site">@site</option>
+                }
+            </select>
+        </div>
+    }
+
+    <div class="d-flex align-items-center mb-2">
+        <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
+        <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
+        @if (showRetractReview)
+        {
+            <button class="btn btn-warning me-2" @onclick="RetractReview">Retract Review</button>
+        }
+        <button class="btn btn-danger me-2" @onclick="CloseEditor">Close</button>
+        <span class="ms-auto"><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
     </div>
 }
-
-<div class="d-flex align-items-center mb-2">
-    <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
-    <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
-    @if (showRetractReview)
-    {
-        <button class="btn btn-warning me-2" @onclick="RetractReview">Retract Review</button>
-    }
-    <button class="btn btn-danger me-2" @onclick="CloseEditor">Close</button>
-    <span class="ms-auto"><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
-</div>
 
 @if (posts == null)
 {
     <p><em>Loading posts...</em></p>
 }
-else
+else if (showTable)
 {
     <div class="table-scroll">
         <table class="table table-hover">

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -22,6 +22,8 @@ public partial class Edit : IAsyncDisposable
     private int currentPage = 1;
     private bool isLoading = false;
     private string _content = "<p>Hello, world!</p>";
+    private bool showControls = true;
+    private bool showTable = true;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private" };
 
     private IEnumerable<PostSummary> DisplayPosts
@@ -530,6 +532,16 @@ public partial class Edit : IAsyncDisposable
     private void UpdateDirty()
     {
         isDirty = postTitle != lastSavedTitle || _content != lastSavedContent;
+    }
+
+    private void ToggleControls()
+    {
+        showControls = !showControls;
+    }
+
+    private void ToggleTable()
+    {
+        showTable = !showTable;
     }
 
     private async Task ChangeStatus(PostSummary post, string newStatus)

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -153,6 +153,7 @@ code {
 .table-scroll {
     height: 300px;
     overflow-y: auto;
+    resize: vertical;
 }
 
 .article-row {

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -3,8 +3,8 @@ window.myTinyMceConfig = {
   branding: false,
   statusbar: true,
   resize: 'both',
-  plugins: 'code media table',
-  toolbar: 'undo redo | bold italic | table | code mediaLibraryButton customButton showInfoButton',
+  plugins: 'code media table fullscreen',
+  toolbar: 'undo redo | bold italic | table | code mediaLibraryButton customButton showInfoButton fullscreen',
   mediaSource: null,
   setup: function (editor) {
     editor.ui.registry.addButton('customButton', {


### PR DESCRIPTION
## Summary
- allow collapsing metadata and posts table on `Edit` page
- make posts table area resizable
- add fullscreen plugin to TinyMCE config

## Testing
- `dotnet build` *(fails: command not found)*
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857a103b5d88322ae4353fd3d73268c