### PR TITLE
Add toggle to show trashed articles

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -60,6 +60,10 @@
 }
 else if (showTable)
 {
+    <div class="form-check form-switch mb-2">
+        <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" />
+        <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
+    </div>
     <div class="table-scroll">
         <table class="table table-hover">
             <thead>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -24,6 +24,7 @@ public partial class Edit : IAsyncDisposable
     private string _content = "<p>Hello, world!</p>";
     private bool showControls = true;
     private bool showTable = true;
+    private bool showTrashed = false;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
 
     private IEnumerable<PostSummary> DisplayPosts
@@ -51,6 +52,10 @@ public partial class Edit : IAsyncDisposable
             foreach (var p in posts)
             {
                 if (postId != null && p.Id == postId)
+                {
+                    continue;
+                }
+                if (!showTrashed && string.Equals(p.Status, "trash", StringComparison.OrdinalIgnoreCase))
                 {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- add UI switch above article table to toggle inclusion of trashed posts
- track new `showTrashed` flag in the editor logic and filter DisplayPosts accordingly

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857b0faaf4c832281c05132c81896f8