### PR TITLE
Refactor Edit page to use @bind:after

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -26,13 +26,13 @@
 
     <div class="mb-3">
         <label class="form-label" for="postTitle">Title</label>
-        <input id="postTitle" class="form-control" @bind="postTitle" @oninput="TitleInput" />
+        <input id="postTitle" class="form-control" @bind="postTitle" @bind:event="oninput" @bind:after="OnTitleChanged" />
     </div>
     @if (mediaSources.Any())
     {
         <div class="mb-3">
             <label class="form-label" for="mediaSource">Media Source</label>
-            <select id="mediaSource" class="form-select" value="@selectedMediaSource" @onchange="OnMediaSourceChanged">
+            <select id="mediaSource" class="form-select" @bind="selectedMediaSource" @bind:after="OnMediaSourceChanged">
                 <option value="">-- choose media site --</option>
                 @foreach (var site in mediaSources)
                 {
@@ -61,7 +61,7 @@
 else if (showTable)
 {
     <div class="form-check form-switch mb-2">
-        <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @onchange="ShowTrashedChanged" />
+        <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @bind:after="OnShowTrashedChanged" />
         <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
     </div>
     <div class="table-scroll">
@@ -114,5 +114,5 @@ else if (showTable)
 
 
 
-<TinyMCEEditor @bind-Value="_content" OnContentChanged="ContentChanged" />
+<TinyMCEEditor @bind-Value="_content" @bind-Value:after="OnContentChanged" />
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -524,9 +524,8 @@ public partial class Edit : IAsyncDisposable
         await InvokeAsync(StateHasChanged);
     }
 
-    private async Task OnMediaSourceChanged(ChangeEventArgs e)
+    private async Task OnMediaSourceChanged()
     {
-        selectedMediaSource = e.Value?.ToString();
         if (string.IsNullOrEmpty(selectedMediaSource))
         {
             await JS.InvokeVoidAsync("localStorage.removeItem", "mediaSource");
@@ -538,15 +537,13 @@ public partial class Edit : IAsyncDisposable
         await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
     }
 
-    private void TitleInput(ChangeEventArgs e)
+    private void OnTitleChanged()
     {
-        postTitle = e.Value?.ToString() ?? string.Empty;
         UpdateDirty();
     }
 
-    private void ContentChanged(string value)
+    private void OnContentChanged()
     {
-        _content = value;
         UpdateDirty();
     }
 
@@ -565,7 +562,7 @@ public partial class Edit : IAsyncDisposable
         showTable = !showTable;
     }
 
-    private async Task ShowTrashedChanged(ChangeEventArgs _)
+    private async Task OnShowTrashedChanged()
     {
         await JS.InvokeVoidAsync("localStorage.setItem", ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
     }


### PR DESCRIPTION
## Summary
- use `@bind:event` and `@bind:after` for the post title input
- bind `selectedMediaSource` and invoke logic via `@bind:after`
- bind change logic for the show trashed toggle
- call editor change logic with `@bind-Value:after`
- update code-behind to match new method signatures

## Testing
- `dotnet build -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857bb802d3c8322a9dde77b4176a27c