### PR TITLE
Apply bind-after pattern to editor component

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -15,13 +15,10 @@
     [Parameter]
     public EventCallback<string> ValueChanged { get; set; }
 
-    [Parameter]
-    public EventCallback<string> OnContentChanged { get; set; }
 
     private async Task OnEditorValueChanged(string newValue)
     {
         Value = newValue;
         await ValueChanged.InvokeAsync(newValue);
-        await OnContentChanged.InvokeAsync(newValue);
     }
 }


### PR DESCRIPTION
## Summary
- drop the unused `OnContentChanged` callback from `TinyMCEEditor`

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6857bcf68c8c8322bec9717f6ed307b1