### PR TITLE
Update posts fetch limit

### DIFF
--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -378,7 +378,7 @@ public partial class Edit : IAsyncDisposable
             return;
         }
 
-        var url = CombineUrl(endpoint, $"/wp/v2/posts?context=edit&status=any&page={page}&_embed");
+        var url = CombineUrl(endpoint, $"/wp/v2/posts?context=edit&status=any&page={page}&per_page=100&_embed");
         try
         {
             using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));


### PR DESCRIPTION
## Summary
- load up to 100 posts per request in the edit page

## Testing
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857d0492b9c832291c4f02e6b6cc65c