### PR TITLE
Enable infinite scroll for post table

### DIFF
--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -57,7 +57,7 @@ public partial class Edit
             }
             StateHasChanged();
         }
-
+        await ObserveScrollAsync();
     }
 
     private async Task SetupWordPressClientAsync()

--- a/Pages/Edit.Scroll.cs
+++ b/Pages/Edit.Scroll.cs
@@ -1,0 +1,33 @@
+using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
+
+namespace BlazorWP.Pages;
+
+public partial class Edit
+{
+    private DotNetObjectReference<Edit>? _scrollRef;
+    private ElementReference scrollAnchor;
+
+    [JSInvokable]
+    public async Task OnIntersection()
+    {
+        await PullMore();
+    }
+
+    private async Task ObserveScrollAsync()
+    {
+        if (!showTable) return;
+        _scrollRef ??= DotNetObjectReference.Create(this);
+        await JS.InvokeVoidAsync("infiniteScroll.observe", scrollAnchor, _scrollRef);
+    }
+
+    private async Task DisconnectScrollAsync()
+    {
+        await JS.InvokeVoidAsync("infiniteScroll.disconnect");
+        if (_scrollRef != null)
+        {
+            _scrollRef.Dispose();
+            _scrollRef = null;
+        }
+    }
+}

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -107,8 +107,8 @@ else if (showTable)
                 }
             </tbody>
         </table>
+        <div @ref="scrollAnchor"></div>
     </div>
-    <button class="btn btn-outline-primary w-100 mt-2" @onclick="PullMore" disabled="@(!hasMore)">Pull more</button>
 }
 
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -94,6 +94,7 @@ public partial class Edit : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
+        _ = DisconnectScrollAsync();
         return ValueTask.CompletedTask;
     }
 }

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -42,6 +42,7 @@
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
     <script src="js/tinyMceConfig.js"></script>
+    <script src="js/infiniteScroll.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary
- remove `Pull more` button in editor table
- load posts on scroll via IntersectionObserver
- wire up JS for infinite scrolling

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6857dcc6b6608322aaa9cb8ef09a722f