### PR TITLE
Fix editor infinite scroll trigger

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -41,9 +41,17 @@ public partial class Edit
         showControls = !showControls;
     }
 
-    private void ToggleTable()
+    private async Task ToggleTable()
     {
         showTable = !showTable;
+        if (showTable)
+        {
+            await ObserveScrollAsync();
+        }
+        else
+        {
+            await DisconnectScrollAsync();
+        }
     }
 
     private async Task OnShowTrashedChanged()

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -107,7 +107,7 @@ else if (showTable)
                 }
             </tbody>
         </table>
-        <div @ref="scrollAnchor"></div>
+        <div @ref="scrollAnchor" class="scroll-anchor"></div>
     </div>
 }
 

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -156,6 +156,10 @@ code {
     resize: vertical;
 }
 
+.scroll-anchor {
+    height: 1px;
+}
+
 .article-row {
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- style scroll anchor so intersection is detectable
- call JS interop when posts table is toggled
- use CSS class on sentinel element

## Testing
- `dotnet build --nologo` *(fails: command not found)*
- `dotnet test --no-build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e50c136883229821a58a764cdb03