### PR TITLE
Fix infinite scroll batch size

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -22,8 +22,9 @@ public partial class Edit
         var qb = new PostsQueryBuilder
         {
             Context = Context.Edit,
-            Page = page,
-            PerPage = 10,
+            Page = 1,
+            PerPage = page == 1 && !append ? 10 : 100,
+            Offset = page == 1 && !append ? 0 : posts.Count,
             Embed = true,
             Statuses = new List<Status> { Status.Publish, Status.Private, Status.Draft, Status.Pending, Status.Future, Status.Trash }
         };


### PR DESCRIPTION
## Summary
- fetch 100 posts on each infinite scroll after the initial 10

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857e6caa0148322a42747f7edc9c351