### PR TITLE
Add refresh posts capability

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -137,4 +137,13 @@ public partial class Edit
         UpdateDirty();
         await InvokeAsync(StateHasChanged);
     }
+
+    private async Task RefreshPosts()
+    {
+        currentPage = 1;
+        hasMore = true;
+        await DisconnectScrollAsync();
+        await LoadPosts(currentPage);
+        await ObserveScrollAsync();
+    }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -50,7 +50,10 @@
             <button class="btn btn-warning me-2" @onclick="RetractReview">Retract Review</button>
         }
         <button class="btn btn-danger me-2" @onclick="CloseEditor">Close</button>
-        <span class="ms-auto"><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
+        <div class="ms-auto d-flex align-items-center">
+            <span><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
+            <button class="btn btn-sm btn-outline-secondary ms-2" @onclick="RefreshPosts">Refresh</button>
+        </div>
     </div>
 }
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -54,7 +54,7 @@ public partial class Edit : IAsyncDisposable
                 }
             }
 
-            foreach (var p in posts)
+            foreach (var p in posts.OrderByDescending(p => p.Id))
             {
                 if (postId != null && p.Id == postId)
                 {


### PR DESCRIPTION
## Summary
- sort articles by descending ID
- add Refresh button near the status indicator
- implement refresh logic for posts table

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857ec9c717083228ad6153715cb6abf