### PR TITLE
Fix duplicate rows when loading posts

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -22,9 +22,8 @@ public partial class Edit
         var qb = new PostsQueryBuilder
         {
             Context = Context.Edit,
-            Page = 1,
+            Page = page,
             PerPage = page == 1 && !append ? 10 : 20,
-            Offset = page == 1 && !append ? 0 : posts.Count,
             Embed = true,
             Statuses = new List<Status> { Status.Publish, Status.Private, Status.Draft, Status.Pending, Status.Future, Status.Trash }
         };


### PR DESCRIPTION
## Summary
- query the correct page from WordPress when loading posts

## Testing
- `dotnet test --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857f02f6fa883228529e2ea5156ee9c