### PR TITLE
Fix post selection sync

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -147,6 +147,7 @@ public partial class Edit
 
     private async Task CloseEditor()
     {
+        var closedId = postId;
         postId = null;
         postTitle = string.Empty;
         _content = string.Empty;
@@ -154,8 +155,16 @@ public partial class Edit
         lastSavedContent = string.Empty;
         showRetractReview = false;
         var list = await LoadDraftStatesAsync();
-        list.RemoveAll(d => d.PostId == postId);
+        list.RemoveAll(d => d.PostId == closedId);
         await SaveDraftStatesAsync(list);
+        if (closedId != null)
+        {
+            var placeholder = posts.FirstOrDefault(p => p.Id == closedId && string.IsNullOrEmpty(p.Status));
+            if (placeholder != null)
+            {
+                posts.Remove(placeholder);
+            }
+        }
         UpdateDirty();
         await InvokeAsync(StateHasChanged);
     }

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -42,6 +42,18 @@ public partial class Edit
         currentPage = 1;
         hasMore = true;
         await LoadPosts(currentPage);
+        if (postId != null && !posts.Any(p => p.Id == postId))
+        {
+            posts.Add(new PostSummary
+            {
+                Id = postId.Value,
+                Title = postTitle,
+                Author = 0,
+                AuthorName = string.Empty,
+                Status = string.Empty,
+                Date = null
+            });
+        }
         UpdateDirty();
     }
 

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -76,6 +76,18 @@ public partial class Edit
             _content = item.Content ?? string.Empty;
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            if (postId != null && !posts.Any(p => p.Id == postId))
+            {
+                posts.Add(new PostSummary
+                {
+                    Id = postId.Value,
+                    Title = postTitle,
+                    Author = 0,
+                    AuthorName = string.Empty,
+                    Status = string.Empty,
+                    Date = null
+                });
+            }
             return true;
         }
         return false;
@@ -97,6 +109,18 @@ public partial class Edit
             _content = post.Content?.Raw ?? string.Empty;
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            if (!posts.Any(p => p.Id == id))
+            {
+                posts.Add(new PostSummary
+                {
+                    Id = post.Id,
+                    Title = post.Title?.Rendered ?? postTitle,
+                    Author = post.Author,
+                    AuthorName = post.Embedded?.Author?.FirstOrDefault()?.Name ?? string.Empty,
+                    Status = post.Status.ToString().ToLowerInvariant(),
+                    Date = post.Date
+                });
+            }
         }
         catch (Exception ex)
         {
@@ -143,6 +167,10 @@ public partial class Edit
         hasMore = true;
         await DisconnectScrollAsync();
         await LoadPosts(currentPage);
+        if (postId != null && !posts.Any(p => p.Id == postId))
+        {
+            await LoadPostFromServerAsync(postId.Value);
+        }
         await ObserveScrollAsync();
     }
 }


### PR DESCRIPTION
## Summary
- include selected post in posts collection when loaded
- keep selected post visible after refresh
- keep editor draft placeholder trimmed when closing editor

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6857f6dd9c948322a0a9f112b0f1f0a4