### PR TITLE
Add debug logs for editor table interactions

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -10,6 +10,7 @@ public partial class Edit
 {
     private async Task LoadPosts(int page = 1, bool append = false)
     {
+        Console.WriteLine($"[LoadPosts] page={page}, append={append}");
         if (page == 1 && !append)
         {
             posts.Clear();
@@ -45,10 +46,12 @@ public partial class Edit
                 });
                 count++;
             }
+            Console.WriteLine($"[LoadPosts] loaded {count} posts");
             hasMore = count > 0;
         }
         catch
         {
+            Console.WriteLine("[LoadPosts] error fetching posts");
             hasMore = false;
         }
 
@@ -67,10 +70,12 @@ public partial class Edit
 
     private async Task<bool> TryLoadDraftAsync(int? id)
     {
+        Console.WriteLine($"[TryLoadDraftAsync] id={id}");
         var list = await LoadDraftStatesAsync();
         var item = list.FirstOrDefault(d => d.PostId == id);
         if (item != null)
         {
+            Console.WriteLine("[TryLoadDraftAsync] draft found");
             postId = item.PostId;
             postTitle = item.Title ?? string.Empty;
             _content = item.Content ?? string.Empty;
@@ -90,11 +95,13 @@ public partial class Edit
             }
             return true;
         }
+        Console.WriteLine("[TryLoadDraftAsync] no draft found");
         return false;
     }
 
     private async Task LoadPostFromServerAsync(int id)
     {
+        Console.WriteLine($"[LoadPostFromServerAsync] id={id}");
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -125,11 +132,13 @@ public partial class Edit
         catch (Exception ex)
         {
             status = $"Error: {ex.Message}";
+            Console.WriteLine($"[LoadPostFromServerAsync] exception: {ex.Message}");
         }
     }
 
     private async Task OpenPost(PostSummary post)
     {
+        Console.WriteLine($"[OpenPost] click id={post.Id}, title={post.Title}");
         if (post.Id == postId)
         {
             return;
@@ -138,16 +147,19 @@ public partial class Edit
         if (isDirty)
         {
             await SaveLocalDraftAsync();
+            Console.WriteLine("[OpenPost] autosaved dirty draft");
         }
 
         if (!await TryLoadDraftAsync(post.Id))
         {
             if (post.Id > 0)
             {
+                Console.WriteLine("[OpenPost] loading from server");
                 await LoadPostFromServerAsync(post.Id);
             }
             else
             {
+                Console.WriteLine("[OpenPost] new empty post");
                 postId = null;
                 postTitle = string.Empty;
                 _content = string.Empty;
@@ -158,11 +170,13 @@ public partial class Edit
 
         showRetractReview = post.Status == "pending";
         UpdateDirty();
+        Console.WriteLine($"[OpenPost] completed. postId={postId}");
         await InvokeAsync(StateHasChanged);
     }
 
     private async Task RefreshPosts()
     {
+        Console.WriteLine("[RefreshPosts] refreshing");
         currentPage = 1;
         hasMore = true;
         await DisconnectScrollAsync();


### PR DESCRIPTION
## Summary
- log post loading details when populating article table
- log decisions made during draft retrieval and post loading
- log click actions and resulting selected post state
- log table refresh actions

## Testing
- `dotnet build -v minimal` *(fails: dotnet not found)*


------
https://chatgpt.com/codex/tasks/task_e_6857fe6be25883229536a262f0ee51e4