### PR TITLE
Add extensive logging for editor actions

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -10,6 +10,7 @@ public partial class Edit
 {
     private async Task SaveDraft()
     {
+        Console.WriteLine("[SaveDraft] starting");
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -58,10 +59,12 @@ public partial class Edit
         lastSavedContent = _content;
         UpdateDirty();
         showRetractReview = false;
+        Console.WriteLine("[SaveDraft] completed");
     }
 
     private async Task SubmitForReview()
     {
+        Console.WriteLine("[SubmitForReview] starting");
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -113,10 +116,12 @@ public partial class Edit
         hasMore = true;
         await LoadPosts(currentPage);
         showRetractReview = true;
+        Console.WriteLine("[SubmitForReview] completed");
     }
 
     private async Task RetractReview()
     {
+        Console.WriteLine("[RetractReview] starting");
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -143,10 +148,12 @@ public partial class Edit
         {
             status = $"Error: {ex.Message}";
         }
+        Console.WriteLine("[RetractReview] completed");
     }
 
     private async Task CloseEditor()
     {
+        Console.WriteLine("[CloseEditor] starting");
         var closedId = postId;
         postId = null;
         postTitle = string.Empty;
@@ -167,6 +174,7 @@ public partial class Edit
         }
         UpdateDirty();
         await InvokeAsync(StateHasChanged);
+        Console.WriteLine("[CloseEditor] completed");
     }
 
     private async Task SaveLocalDraftAsync()

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -18,22 +18,26 @@ public partial class Edit
         {
             await JS.InvokeVoidAsync("localStorage.setItem", "mediaSource", selectedMediaSource);
         }
+        Console.WriteLine($"[OnMediaSourceChanged] source='{selectedMediaSource}'");
         await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
     }
 
     private void OnTitleChanged()
     {
+        Console.WriteLine($"[OnTitleChanged] length={postTitle.Length}");
         UpdateDirty();
     }
 
     private void OnContentChanged()
     {
+        Console.WriteLine($"[OnContentChanged] length={_content.Length}");
         UpdateDirty();
     }
 
     private void UpdateDirty()
     {
         isDirty = postTitle != lastSavedTitle || _content != lastSavedContent;
+        Console.WriteLine($"[UpdateDirty] isDirty={isDirty}");
     }
 
     private void ToggleControls()

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -10,6 +10,7 @@ public partial class Edit
 {
     protected override async Task OnInitializedAsync()
     {
+        Console.WriteLine("[OnInitializedAsync] starting");
         var draftsJson = await JS.InvokeAsync<string?>("localStorage.getItem", DraftsKey);
         if (!string.IsNullOrEmpty(draftsJson))
         {
@@ -55,12 +56,14 @@ public partial class Edit
             });
         }
         UpdateDirty();
+        Console.WriteLine("[OnInitializedAsync] completed");
     }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
+            Console.WriteLine("[OnAfterRenderAsync] firstRender");
             mediaSources = await JwtService.GetSiteInfoKeysAsync();
             selectedMediaSource = await JS.InvokeAsync<string?>("localStorage.getItem", "mediaSource");
             if (!string.IsNullOrEmpty(selectedMediaSource))
@@ -68,6 +71,10 @@ public partial class Edit
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
             StateHasChanged();
+        }
+        else
+        {
+            Console.WriteLine("[OnAfterRenderAsync] subsequent render");
         }
         await ObserveScrollAsync();
     }
@@ -79,15 +86,18 @@ public partial class Edit
         {
             client = null;
             baseUrl = null;
+            Console.WriteLine("[SetupWordPressClientAsync] no endpoint configured");
             return;
         }
 
         baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        Console.WriteLine($"[SetupWordPressClientAsync] baseUrl={baseUrl}");
         client = new WordPressClient(baseUrl);
         var token = await JwtService.GetCurrentJwtAsync();
         if (!string.IsNullOrEmpty(token))
         {
             client.Auth.SetJWToken(token);
+            Console.WriteLine("[SetupWordPressClientAsync] token configured");
         }
     }
 }

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -79,6 +79,7 @@ public partial class Edit
             postId = item.PostId;
             postTitle = item.Title ?? string.Empty;
             _content = item.Content ?? string.Empty;
+            Console.WriteLine($"[TryLoadDraftAsync] loaded draft title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
             if (postId != null && !posts.Any(p => p.Id == postId))
@@ -114,6 +115,7 @@ public partial class Edit
             postId = id;
             postTitle = post.Title?.Raw ?? string.Empty;
             _content = post.Content?.Raw ?? string.Empty;
+            Console.WriteLine($"[LoadPostFromServerAsync] loaded title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
             if (!posts.Any(p => p.Id == id))
@@ -163,6 +165,7 @@ public partial class Edit
                 postId = null;
                 postTitle = string.Empty;
                 _content = string.Empty;
+                Console.WriteLine("[OpenPost] cleared title and content");
                 lastSavedTitle = postTitle;
                 lastSavedContent = _content;
             }


### PR DESCRIPTION
## Summary
- extend logging in event handlers and lifecycle methods
- log draft loading and server fetch details
- log major editor operations like save, submit, retract and close

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858008ec260832284b0ef08bf0e1633