### PR TITLE
Fix TinyMCE editor updates on article change

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -1,10 +1,11 @@
 @using TinyMCE.Blazor
 <div class="tiny-editor-wrapper">
-    <Editor 
-        ScriptSrc="libman/tinymce/tinymce.min.js" 
+    <Editor
+        Id="articleEditor"
+        ScriptSrc="libman/tinymce/tinymce.min.js"
         LicenseKey="gpl"
         JsConfSrc="myTinyMceConfig"
-        Value="@Value" 
+        Value="@Value"
         ValueChanged="@OnEditorValueChanged" />
 </div>
 

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -75,6 +75,7 @@ public partial class Edit
         else
         {
             Console.WriteLine("[OnAfterRenderAsync] subsequent render");
+            await JS.InvokeVoidAsync("setTinyEditorContent", _content);
         }
         await ObserveScrollAsync();
     }

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -113,3 +113,9 @@ window.myTinyMceConfig = {
 window.setTinyMediaSource = function (url) {
   window.myTinyMceConfig.mediaSource = url || null;
 };
+
+window.setTinyEditorContent = function (html) {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    tinymce.get('articleEditor').setContent(html || '');
+  }
+};


### PR DESCRIPTION
## Summary
- assign a fixed ID to the TinyMCE editor component
- expose a JS helper to update editor content
- refresh editor content from `OnAfterRenderAsync` when the page re-renders

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858089e157c83228418252201d3cb69