### PR TITLE
Fix TinyMCE new post initialization

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -155,12 +155,7 @@ public partial class Edit
     {
         //Console.WriteLine("[CloseEditor] starting");
         var closedId = postId;
-        postId = null;
-        postTitle = string.Empty;
-        _content = string.Empty;
-        lastSavedTitle = string.Empty;
-        lastSavedContent = string.Empty;
-        showRetractReview = false;
+        ResetEditorState();
         var list = await LoadDraftStatesAsync();
         list.RemoveAll(d => d.PostId == closedId);
         await SaveDraftStatesAsync(list);

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -12,25 +12,31 @@ public partial class Edit
     {
         //Console.WriteLine("[OnInitializedAsync] starting");
         var draftsJson = await JS.InvokeAsync<string?>("localStorage.getItem", DraftsKey);
+        DraftInfo? latestDraft = null;
         if (!string.IsNullOrEmpty(draftsJson))
         {
             try
             {
                 var list = JsonSerializer.Deserialize<List<DraftInfo>>(draftsJson);
-                var latest = list?.OrderByDescending(d => d.LastUpdated).FirstOrDefault();
-                if (latest != null)
-                {
-                    postId = latest.PostId;
-                    postTitle = latest.Title ?? string.Empty;
-                    _content = latest.Content ?? string.Empty;
-                    lastSavedTitle = postTitle;
-                    lastSavedContent = _content;
-                }
+                latestDraft = list?.OrderByDescending(d => d.LastUpdated).FirstOrDefault();
             }
             catch
             {
                 // ignore deserialization errors
             }
+        }
+
+        if (latestDraft != null)
+        {
+            postId = latestDraft.PostId;
+            postTitle = latestDraft.Title ?? string.Empty;
+            _content = latestDraft.Content ?? string.Empty;
+            lastSavedTitle = postTitle;
+            lastSavedContent = _content;
+        }
+        else
+        {
+            ResetEditorState();
         }
 
         var trashedSetting = await JS.InvokeAsync<string?>("localStorage.getItem", ShowTrashedKey);

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -162,12 +162,7 @@ public partial class Edit
             else
             {
                 //Console.WriteLine("[OpenPost] new empty post");
-                postId = null;
-                postTitle = string.Empty;
-                _content = string.Empty;
-                //Console.WriteLine("[OpenPost] cleared title and content");
-                lastSavedTitle = postTitle;
-                lastSavedContent = _content;
+                ResetEditorState();
             }
         }
 

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -1,0 +1,20 @@
+using System.Text.Json;
+using Microsoft.JSInterop;
+using WordPressPCL;
+using WordPressPCL.Models;
+using WordPressPCL.Utility;
+
+namespace BlazorWP.Pages;
+
+public partial class Edit
+{
+    private void ResetEditorState()
+    {
+        postId = null;
+        postTitle = string.Empty;
+        _content = string.Empty;
+        lastSavedTitle = string.Empty;
+        lastSavedContent = string.Empty;
+        showRetractReview = false;
+    }
+}

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -23,7 +23,7 @@ public partial class Edit : IAsyncDisposable
     private bool hasMore = true;
     private int currentPage = 1;
     private bool isLoading = false;
-    private string _content = "<p>Hello, world!</p>";
+    private string _content = string.Empty;
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;


### PR DESCRIPTION
## Summary
- initialize TinyMCE content to empty instead of placeholder
- add `ResetEditorState` helper
- call the reset method when no draft exists, opening a new post, or closing the editor

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68588a8e05b083229119e1a19ef11e4d