### PR TITLE
Add New post button

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -96,6 +96,32 @@ public partial class Edit
         }
     }
 
+    private async Task NewPost()
+    {
+        if (postId != null)
+        {
+            if (isDirty)
+            {
+                await SaveLocalDraftAsync();
+            }
+        }
+        else
+        {
+            var list = await LoadDraftStatesAsync();
+            list.RemoveAll(d => d.PostId == null);
+            await SaveDraftStatesAsync(list);
+        }
+
+        if (!await TryLoadDraftAsync(null))
+        {
+            ResetEditorState();
+        }
+
+        showRetractReview = false;
+        UpdateDirty();
+        await InvokeAsync(StateHasChanged);
+    }
+
     private static string GetStatusButtonClass(string? status)
     {
         return status switch

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -43,6 +43,7 @@
     }
 
     <div class="d-flex align-items-center mb-2">
+        <button class="btn btn-success me-2" @onclick="NewPost">New</button>
         <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
         <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
         @if (showRetractReview)


### PR DESCRIPTION
## Summary
- add `New` button in the editor UI
- implement `NewPost` handler to handle new post logic, discard or restore draft

## Testing
- `dotnet build BlazorWP.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858a5927cd483229940dd9f64c70646