### PR TITLE
Add edit mode toggle for posts

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -118,6 +118,7 @@ public partial class Edit
         }
 
         showRetractReview = false;
+        isEditing = true;
         UpdateDirty();
         await InvokeAsync(StateHasChanged);
     }

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -138,7 +138,7 @@ public partial class Edit
         }
     }
 
-    private async Task OpenPost(PostSummary post)
+    private async Task OpenPost(PostSummary post, bool edit = false)
     {
         //Console.WriteLine($"[OpenPost] click id={post.Id}, title={post.Title}");
         if (post.Id == postId)
@@ -169,7 +169,13 @@ public partial class Edit
         showRetractReview = post.Status == "pending";
         UpdateDirty();
         //Console.WriteLine($"[OpenPost] completed. postId={postId}");
+        isEditing = edit;
         await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task EditPost(PostSummary post)
+    {
+        await OpenPost(post, true);
     }
 
     private async Task RefreshPosts()

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -16,5 +16,6 @@ public partial class Edit
         lastSavedTitle = string.Empty;
         lastSavedContent = string.Empty;
         showRetractReview = false;
+        isEditing = false;
     }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -72,6 +72,7 @@ else if (showTable)
         <table class="table table-hover">
             <thead>
                 <tr>
+                    <th>Edit</th>
                     <th>Id</th>
                     <th>Title</th>
                     <th>Author</th>
@@ -84,6 +85,9 @@ else if (showTable)
                 @foreach (var p in DisplayPosts)
                 {
                     <tr @key="p.Id" class="article-row @(IsSelected(p, postId) ? "table-primary" : null)" @onclick="() => OpenPost(p)">
+                        <td>
+                            <button class="btn btn-sm btn-primary" @onclick="() => EditPost(p)" @onclick:stopPropagation="true">Edit</button>
+                        </td>
                         <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
                         <td>@p.Title</td>
                         <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
@@ -118,5 +122,14 @@ else if (showTable)
 
 
 
-<TinyMCEEditor @bind-Value="_content" @bind-Value:after="OnContentChanged" />
+@if (isEditing)
+{
+    <TinyMCEEditor @bind-Value="_content" @bind-Value:after="OnContentChanged" />
+}
+else
+{
+    <div class="border p-2" @onclick="() => isEditing = true">
+        @((MarkupString)_content)
+    </div>
+}
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -27,6 +27,7 @@ public partial class Edit : IAsyncDisposable
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;
+    private bool isEditing = false;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
     private string? baseUrl;


### PR DESCRIPTION
## Summary
- show an Edit button in the posts table
- open a post read-only when clicking the row
- allow switching to the TinyMCE editor via the Edit button

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859d353a6fc8322800ec1148d27e1ea