### PR TITLE
Decouple TinyMCE editor from keystroke binding

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -1,25 +1,52 @@
 @using TinyMCE.Blazor
+@inject IJSRuntime JS
+@implements IAsyncDisposable
 <div class="tiny-editor-wrapper">
     <Editor
         Id="articleEditor"
         ScriptSrc="libman/tinymce/tinymce.min.js"
         LicenseKey="gpl"
-        JsConfSrc="myTinyMceConfig"
-        Value="@Value"
-        ValueChanged="@OnEditorValueChanged" />
+        JsConfSrc="myTinyMceConfig" />
 </div>
 
 @code {
     [Parameter]
-    public string Value { get; set; } = string.Empty;
+    public EventCallback<string> ContentBlurred { get; set; }
 
     [Parameter]
-    public EventCallback<string> ValueChanged { get; set; }
+    public EventCallback FirstChange { get; set; }
 
+    private DotNetObjectReference<TinyMCEEditor>? _objRef;
 
-    private async Task OnEditorValueChanged(string newValue)
+    protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        Value = newValue;
-        await ValueChanged.InvokeAsync(newValue);
+        if (firstRender)
+        {
+            _objRef = DotNetObjectReference.Create(this);
+            await JS.InvokeVoidAsync("registerTinyEditorCallbacks", _objRef);
+        }
+    }
+
+    public async Task<string> GetContentAsync()
+        => await JS.InvokeAsync<string>("getTinyEditorContent");
+
+    public async Task SetContentAsync(string html)
+        => await JS.InvokeVoidAsync("setTinyEditorContent", html);
+
+    [JSInvokable]
+    public async Task OnEditorBlur()
+    {
+        var content = await GetContentAsync();
+        await ContentBlurred.InvokeAsync(content);
+    }
+
+    [JSInvokable]
+    public Task OnEditorDirty()
+        => FirstChange.InvokeAsync();
+
+    public ValueTask DisposeAsync()
+    {
+        _objRef?.Dispose();
+        return ValueTask.CompletedTask;
     }
 }

--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -11,6 +11,11 @@ public partial class Edit
     private async Task SaveDraft()
     {
         //Console.WriteLine("[SaveDraft] starting");
+        if (editorComp != null)
+        {
+            _content = await editorComp.GetContentAsync();
+        }
+
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -65,6 +70,10 @@ public partial class Edit
     private async Task SubmitForReview()
     {
         //Console.WriteLine("[SubmitForReview] starting");
+        if (editorComp != null)
+        {
+            _content = await editorComp.GetContentAsync();
+        }
         if (client == null)
         {
             status = "No WordPress endpoint configured.";
@@ -156,6 +165,10 @@ public partial class Edit
         //Console.WriteLine("[CloseEditor] starting");
         var closedId = postId;
         ResetEditorState();
+        if (editorComp != null)
+        {
+            await editorComp.SetContentAsync(_content);
+        }
         var list = await LoadDraftStatesAsync();
         list.RemoveAll(d => d.PostId == closedId);
         await SaveDraftStatesAsync(list);

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -28,9 +28,16 @@ public partial class Edit
         UpdateDirty();
     }
 
-    private void OnContentChanged()
+    private void OnContentDirty()
     {
-        //Console.WriteLine($"[OnContentChanged] length={_content.Length}");
+        isDirty = true;
+    }
+
+    private async Task OnEditorBlurred(string html)
+    {
+        _content = html;
+        await SaveLocalDraftAsync();
+        lastSavedContent = _content;
         UpdateDirty();
     }
 
@@ -102,6 +109,10 @@ public partial class Edit
         {
             if (isDirty)
             {
+                if (editorComp != null)
+                {
+                    _content = await editorComp.GetContentAsync();
+                }
                 await SaveLocalDraftAsync();
             }
         }
@@ -115,6 +126,10 @@ public partial class Edit
         if (!await TryLoadDraftAsync(null))
         {
             ResetEditorState();
+            if (editorComp != null)
+            {
+                await editorComp.SetContentAsync(_content);
+            }
         }
 
         showRetractReview = false;

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -76,12 +76,11 @@ public partial class Edit
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
+            if (editorComp != null)
+            {
+                await editorComp.SetContentAsync(_content);
+            }
             StateHasChanged();
-        }
-        else
-        {
-            //Console.WriteLine("[OnAfterRenderAsync] subsequent render");
-            await JS.InvokeVoidAsync("setTinyEditorContent", _content);
         }
         await ObserveScrollAsync();
     }

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -83,6 +83,10 @@ public partial class Edit
             //Console.WriteLine($"[TryLoadDraftAsync] loaded draft title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            if (editorComp != null)
+            {
+                await editorComp.SetContentAsync(_content);
+            }
             if (postId != null && !posts.Any(p => p.Id == postId))
             {
                 posts.Add(new PostSummary
@@ -120,6 +124,10 @@ public partial class Edit
             //Console.WriteLine($"[LoadPostFromServerAsync] loaded title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            if (editorComp != null)
+            {
+                await editorComp.SetContentAsync(_content);
+            }
             var existing = posts.FirstOrDefault(p => p.Id == id);
             if (existing == null)
             {
@@ -162,6 +170,10 @@ public partial class Edit
 
         if (isDirty)
         {
+            if (editorComp != null)
+            {
+                _content = await editorComp.GetContentAsync();
+            }
             await SaveLocalDraftAsync();
             //Console.WriteLine("[OpenPost] autosaved dirty draft");
         }
@@ -188,6 +200,10 @@ public partial class Edit
             {
                 //Console.WriteLine("[OpenPost] new empty post");
                 ResetEditorState();
+                if (editorComp != null)
+                {
+                    await editorComp.SetContentAsync(_content);
+                }
             }
         }
 

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -124,7 +124,7 @@ else if (showTable)
 
 @if (isEditing)
 {
-    <TinyMCEEditor @bind-Value="_content" @bind-Value:after="OnContentChanged" />
+    <TinyMCEEditor @ref="editorComp" ContentBlurred="OnEditorBlurred" FirstChange="OnContentDirty" />
 }
 else
 {

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -24,6 +24,7 @@ public partial class Edit : IAsyncDisposable
     private int currentPage = 1;
     private bool isLoading = false;
     private string _content = string.Empty;
+    private TinyMCEEditor? editorComp;
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -119,3 +119,24 @@ window.setTinyEditorContent = function (html) {
     tinymce.get('articleEditor').setContent(html || '');
   }
 };
+
+window.getTinyEditorContent = function () {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    return tinymce.get('articleEditor').getContent();
+  }
+  return '';
+};
+
+window.registerTinyEditorCallbacks = function (dotNetHelper) {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    const editor = tinymce.get('articleEditor');
+    editor.on('blur', function () {
+      dotNetHelper.invokeMethodAsync('OnEditorBlur');
+    });
+    const changeHandler = function () {
+      dotNetHelper.invokeMethodAsync('OnEditorDirty');
+      editor.off('change', changeHandler);
+    };
+    editor.on('change', changeHandler);
+  }
+};


### PR DESCRIPTION
## Summary
- remove Value binding from TinyMCEEditor and expose JS interop API
- add blur and dirty callbacks registered via JS
- update editor JS config with helpers to get content and register events
- manage editor content manually from the Edit page
- autosave draft on blur and mark dirty on first change

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f0d90ed08322bff4c8845d81e6af