### PR TITLE
Ensure editor content loads when opening posts

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -165,10 +165,7 @@ public partial class Edit
         //Console.WriteLine("[CloseEditor] starting");
         var closedId = postId;
         ResetEditorState();
-        if (editorComp != null)
-        {
-            await editorComp.SetContentAsync(_content);
-        }
+        await EnsureEditorContentAsync();
         var list = await LoadDraftStatesAsync();
         list.RemoveAll(d => d.PostId == closedId);
         await SaveDraftStatesAsync(list);

--- a/Pages/Edit.Editor.cs
+++ b/Pages/Edit.Editor.cs
@@ -1,0 +1,19 @@
+using System.Threading.Tasks;
+
+namespace BlazorWP.Pages;
+
+public partial class Edit
+{
+    private async Task EnsureEditorContentAsync()
+    {
+        if (editorComp != null)
+        {
+            await editorComp.SetContentAsync(_content);
+            pendingEditorContent = false;
+        }
+        else
+        {
+            pendingEditorContent = true;
+        }
+    }
+}

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -126,10 +126,7 @@ public partial class Edit
         if (!await TryLoadDraftAsync(null))
         {
             ResetEditorState();
-            if (editorComp != null)
-            {
-                await editorComp.SetContentAsync(_content);
-            }
+            await EnsureEditorContentAsync();
         }
 
         showRetractReview = false;

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -62,6 +62,7 @@ public partial class Edit
             });
         }
         UpdateDirty();
+        await EnsureEditorContentAsync();
         //Console.WriteLine("[OnInitializedAsync] completed");
     }
 
@@ -76,12 +77,18 @@ public partial class Edit
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
-            if (editorComp != null)
-            {
-                await editorComp.SetContentAsync(_content);
-            }
+        }
+
+        if (pendingEditorContent)
+        {
+            await EnsureEditorContentAsync();
+        }
+
+        if (firstRender)
+        {
             StateHasChanged();
         }
+
         await ObserveScrollAsync();
     }
 

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -83,10 +83,7 @@ public partial class Edit
             //Console.WriteLine($"[TryLoadDraftAsync] loaded draft title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
-            if (editorComp != null)
-            {
-                await editorComp.SetContentAsync(_content);
-            }
+            await EnsureEditorContentAsync();
             if (postId != null && !posts.Any(p => p.Id == postId))
             {
                 posts.Add(new PostSummary
@@ -124,10 +121,7 @@ public partial class Edit
             //Console.WriteLine($"[LoadPostFromServerAsync] loaded title length={postTitle.Length}, content length={_content.Length}");
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
-            if (editorComp != null)
-            {
-                await editorComp.SetContentAsync(_content);
-            }
+            await EnsureEditorContentAsync();
             var existing = posts.FirstOrDefault(p => p.Id == id);
             if (existing == null)
             {
@@ -200,10 +194,7 @@ public partial class Edit
             {
                 //Console.WriteLine("[OpenPost] new empty post");
                 ResetEditorState();
-                if (editorComp != null)
-                {
-                    await editorComp.SetContentAsync(_content);
-                }
+                await EnsureEditorContentAsync();
             }
         }
 

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -17,5 +17,6 @@ public partial class Edit
         lastSavedContent = string.Empty;
         showRetractReview = false;
         isEditing = false;
+        pendingEditorContent = true;
     }
 }

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -29,6 +29,7 @@ public partial class Edit : IAsyncDisposable
     private bool showTable = true;
     private bool showTrashed = false;
     private bool isEditing = false;
+    private bool pendingEditorContent = false;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
     private string? baseUrl;


### PR DESCRIPTION
## Summary
- add pending editor content helper
- update lifecycle to push content when needed
- apply helper in post loading and closing logic

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6859f41d36088322951839e789501e66