### PR TITLE
Ensure TinyMCE ready before setting editor content

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -16,6 +16,11 @@
     [Parameter]
     public EventCallback FirstChange { get; set; }
 
+    [Parameter]
+    public EventCallback OnInit { get; set; }
+
+    public bool IsReady { get; private set; }
+
     private DotNetObjectReference<TinyMCEEditor>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -24,6 +29,8 @@
         {
             _objRef = DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("registerTinyEditorCallbacks", _objRef);
+            IsReady = true;
+            await OnInit.InvokeAsync();
         }
     }
 

--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -167,7 +167,7 @@ public partial class Edit
         ResetEditorState();
         if (editorComp != null)
         {
-            await editorComp.SetContentAsync(_content);
+            await SetEditorContentAsync(_content);
         }
         var list = await LoadDraftStatesAsync();
         list.RemoveAll(d => d.PostId == closedId);

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -33,6 +33,15 @@ public partial class Edit
         isDirty = true;
     }
 
+    private async Task HandleEditorReady()
+    {
+        editorReady = true;
+        if (editorComp != null)
+        {
+            await SetEditorContentAsync(_content);
+        }
+    }
+
     private async Task OnEditorBlurred(string html)
     {
         _content = html;
@@ -128,7 +137,7 @@ public partial class Edit
             ResetEditorState();
             if (editorComp != null)
             {
-                await editorComp.SetContentAsync(_content);
+                await SetEditorContentAsync(_content);
             }
         }
 

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -76,10 +76,6 @@ public partial class Edit
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
-            if (editorComp != null)
-            {
-                await editorComp.SetContentAsync(_content);
-            }
             StateHasChanged();
         }
         await ObserveScrollAsync();

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -85,7 +85,7 @@ public partial class Edit
             lastSavedContent = _content;
             if (editorComp != null)
             {
-                await editorComp.SetContentAsync(_content);
+                await SetEditorContentAsync(_content);
             }
             if (postId != null && !posts.Any(p => p.Id == postId))
             {
@@ -126,7 +126,7 @@ public partial class Edit
             lastSavedContent = _content;
             if (editorComp != null)
             {
-                await editorComp.SetContentAsync(_content);
+                await SetEditorContentAsync(_content);
             }
             var existing = posts.FirstOrDefault(p => p.Id == id);
             if (existing == null)
@@ -202,7 +202,7 @@ public partial class Edit
                 ResetEditorState();
                 if (editorComp != null)
                 {
-                    await editorComp.SetContentAsync(_content);
+                    await SetEditorContentAsync(_content);
                 }
             }
         }

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -18,4 +18,14 @@ public partial class Edit
         showRetractReview = false;
         isEditing = false;
     }
+
+    private async Task SetEditorContentAsync(string html)
+    {
+        if (editorComp == null) return;
+        while (!editorComp.IsReady)
+        {
+            await Task.Delay(20);
+        }
+        await editorComp.SetContentAsync(html);
+    }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -124,7 +124,7 @@ else if (showTable)
 
 @if (isEditing)
 {
-    <TinyMCEEditor @ref="editorComp" ContentBlurred="OnEditorBlurred" FirstChange="OnContentDirty" />
+    <TinyMCEEditor @ref="editorComp" OnInit="HandleEditorReady" ContentBlurred="OnEditorBlurred" FirstChange="OnContentDirty" />
 }
 else
 {

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -26,6 +26,7 @@ public partial class Edit : IAsyncDisposable
     private bool isLoading = false;
     private string _content = string.Empty;
     private TinyMCEEditor? editorComp;
+    private bool editorReady = false;
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;


### PR DESCRIPTION
## Summary
- add `OnInit` callback and `IsReady` flag to `TinyMCEEditor`
- defer initial content push until the editor signals ready
- guard all content-setting calls with a helper that waits for readiness

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a45a287e8832298a15e64d2bd2b23