### PR TITLE
Add performance logging for post row selection

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using Microsoft.JSInterop;
+using System.Diagnostics;
 using WordPressPCL;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
@@ -161,10 +162,13 @@ public partial class Edit
 
     private async Task OpenPost(PostSummary post, bool edit = false, bool forceReload = false)
     {
+        var sw = Stopwatch.StartNew();
         //Console.WriteLine($"[OpenPost] click id={post.Id}, title={post.Title}");
         if (post.Id == postId && !forceReload)
         {
             isEditing = edit;
+            sw.Stop();
+            Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms (noop)");
             return;
         }
 
@@ -212,6 +216,8 @@ public partial class Edit
         //Console.WriteLine($"[OpenPost] completed. postId={postId}");
         isEditing = edit;
         await InvokeAsync(StateHasChanged);
+        sw.Stop();
+        Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms");
     }
 
     private async Task EditPost(PostSummary post)


### PR DESCRIPTION
## Summary
- log click performance in OpenPost to debug row interaction delays

## Testing
- `dotnet build --nologo` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a61577dc883228392cac9c775cfb0