### PR TITLE
Log TinyMCE content size after editing

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -37,6 +37,9 @@
     public async Task<string> GetContentAsync()
         => await JS.InvokeAsync<string>("getTinyEditorContent");
 
+    public async Task<int> GetContentLengthAsync()
+        => await JS.InvokeAsync<int>("getTinyEditorContentLength");
+
     public async Task SetContentAsync(string html)
         => await JS.InvokeVoidAsync("setTinyEditorContent", html);
 

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -39,6 +39,13 @@ public partial class Edit
         if (editorComp != null)
         {
             await SetEditorContentAsync(_content);
+            if (editTimerPostId != null && editTimerElapsedMs != null)
+            {
+                var len = await editorComp.GetContentLengthAsync();
+                Console.WriteLine($"[Perf] OpenPost({editTimerPostId}) took {editTimerElapsedMs} ms, length {len}");
+                editTimerPostId = null;
+                editTimerElapsedMs = null;
+            }
         }
     }
 

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -217,7 +217,15 @@ public partial class Edit
         isEditing = edit;
         await InvokeAsync(StateHasChanged);
         sw.Stop();
-        Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms");
+        if (edit)
+        {
+            editTimerElapsedMs = sw.ElapsedMilliseconds;
+            editTimerPostId = post.Id;
+        }
+        else
+        {
+            Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms");
+        }
     }
 
     private async Task EditPost(PostSummary post)

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -31,6 +31,8 @@ public partial class Edit : IAsyncDisposable
     private bool showTable = true;
     private bool showTrashed = false;
     private bool isEditing = false;
+    private int? editTimerPostId;
+    private long? editTimerElapsedMs;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
     private string? baseUrl;

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -127,6 +127,13 @@ window.getTinyEditorContent = function () {
   return '';
 };
 
+window.getTinyEditorContentLength = function () {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    return tinymce.get('articleEditor').getContent().length;
+  }
+  return 0;
+};
+
 window.registerTinyEditorCallbacks = function (dotNetHelper) {
   if (window.tinymce && tinymce.get('articleEditor')) {
     const editor = tinymce.get('articleEditor');


### PR DESCRIPTION
## Summary
- add JS util to get TinyMCE content length
- expose GetContentLengthAsync from TinyMCEEditor
- record content size when editor is ready after clicking Edit
- keep perf timing in OpenPost and output length when ready

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a64f5cfa083228eccb497b9fa9ab1