### PR TITLE
Fix build failure in EditDemo

### DIFF
--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -13,7 +13,6 @@
     <PackageReference Include="MudBlazor" Version="8.8.0" />
     <PackageReference Include="PanoramicData.Blazor" Version="9.0.91" />
     <PackageReference Include="AntDesign" Version="1.4.1.1" />
-    <PackageReference Include="Microsoft.Web.LibraryManager.Build" Version="3.0.71" PrivateAssets="all" />
     <PackageReference Include="TinyMCE.Blazor" Version="2.1.0" />
     <PackageReference Include="WordPressPCL" Version="2.1.0" />
   </ItemGroup>

--- a/Pages/EditDemo.razor
+++ b/Pages/EditDemo.razor
@@ -16,7 +16,6 @@
         LicenseKey="gpl"
         JsConfSrc="myTinyMceConfig"
         @bind-Value="currentText"
-        @bind-Value:event="oninput"
         @bind-Value:after="OnContentChanged" />
 
 <div class="row mt-3">


### PR DESCRIPTION
## Summary
- remove LibraryManager package
- fix duplicate `@bind-Value` attribute usage in EditDemo
- generate local certificate for dev server

## Testing
- `dotnet build --no-restore`
- `dotnet run`

------
https://chatgpt.com/codex/tasks/task_e_685a7a80bb808322b4dfa4e5ec67f40c