### PR TITLE
Add flashing LED indicators to edit demo

### DIFF
--- a/Components/Led.razor
+++ b/Components/Led.razor
@@ -1,0 +1,6 @@
+<div class="led @(IsOn ? "on" : "off")"></div>
+
+@code {
+    [Parameter]
+    public bool IsOn { get; set; }
+}

--- a/Pages/EditDemo.razor
+++ b/Pages/EditDemo.razor
@@ -1,9 +1,15 @@
 @page "/edit-demo"
 @using TinyMCE.Blazor
+@using System.Threading
 
 <PageTitle>Edit Demo</PageTitle>
 
 <h1>Edit Demo</h1>
+
+<div class="mb-2">
+    <Led IsOn="@keyLedOn" />
+    <Led IsOn="@intervalLedOn" />
+</div>
 
 <div class="mb-3">
     <button class="btn btn-primary me-1" @onclick="() => SelectDoc(Doc.A)">Document A</button>
@@ -16,6 +22,7 @@
         LicenseKey="gpl"
         JsConfSrc="myTinyMceConfig"
         @bind-Value="currentText"
+        @bind-Value:event="oninput"
         @bind-Value:after="OnContentChanged" />
 
 <div class="row mt-3">
@@ -41,10 +48,14 @@
     private string docA = string.Empty;
     private string docB = string.Empty;
     private string docC = string.Empty;
+    private bool keyLedOn;
+    private bool intervalLedOn;
+    private PeriodicTimer? flashTimer;
 
     protected override void OnInitialized()
     {
         currentText = docA;
+        _ = StartIntervalFlashAsync();
     }
 
     private void SelectDoc(Doc doc)
@@ -78,8 +89,36 @@
         _ => string.Empty
     };
 
-    private void OnContentChanged()
+    private async Task OnContentChanged()
     {
         SaveCurrent();
+        await FlashKeyLedAsync();
+    }
+
+    private async Task FlashKeyLedAsync()
+    {
+        keyLedOn = true;
+        StateHasChanged();
+        await Task.Delay(150);
+        keyLedOn = false;
+        StateHasChanged();
+    }
+
+    private async Task FlashIntervalLedAsync()
+    {
+        intervalLedOn = true;
+        await InvokeAsync(StateHasChanged);
+        await Task.Delay(150);
+        intervalLedOn = false;
+        await InvokeAsync(StateHasChanged);
+    }
+
+    private async Task StartIntervalFlashAsync()
+    {
+        flashTimer = new PeriodicTimer(TimeSpan.FromSeconds(5));
+        while (await flashTimer.WaitForNextTickAsync())
+        {
+            await FlashIntervalLedAsync();
+        }
     }
 }

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -163,3 +163,19 @@ code {
 .article-row {
     cursor: pointer;
 }
+
+.led {
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    display: inline-block;
+    margin-right: 4px;
+}
+
+.led.off {
+    background-color: #555;
+}
+
+.led.on {
+    background-color: #ff4d4d;
+}


### PR DESCRIPTION
## Summary
- create simple `Led` component
- show LED indicators in `EditDemo`
- flash a red LED on each keystroke via `oninput`
- blink a second LED using `PeriodicTimer`
- style LEDs

## Testing
- `dotnet build --no-restore` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685a7e1cf68483228f72af743c9c3a17