### PR TITLE
Add event indicators to editor demo

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -17,6 +17,9 @@
     public EventCallback FirstChange { get; set; }
 
     [Parameter]
+    public EventCallback Focused { get; set; }
+
+    [Parameter]
     public EventCallback OnInit { get; set; }
 
     public bool IsReady { get; private set; }
@@ -49,6 +52,10 @@
         var content = await GetContentAsync();
         await ContentBlurred.InvokeAsync(content);
     }
+
+    [JSInvokable]
+    public Task OnEditorFocus()
+        => Focused.InvokeAsync();
 
     [JSInvokable]
     public Task OnEditorDirty()

--- a/Pages/EditDemo.razor
+++ b/Pages/EditDemo.razor
@@ -11,12 +11,18 @@
     <button class="btn btn-primary" @onclick="() => SelectDoc(Doc.C)">Document C</button>
 </div>
 
-<Editor Id="demoEditor"
-        ScriptSrc="libman/tinymce/tinymce.min.js"
-        LicenseKey="gpl"
-        JsConfSrc="myTinyMceConfig"
-        @bind-Value="currentText"
-        @bind-Value:after="OnContentChanged" />
+<div class="mb-2 d-flex">
+    <div class="me-2"><span class="led @(initLed ? "flash" : null)"></span> Init</div>
+    <div class="me-2"><span class="led @(focusLed ? "flash" : null)"></span> Focus</div>
+    <div class="me-2"><span class="led @(blurLed ? "flash" : null)"></span> Blur</div>
+    <div class="me-2"><span class="led @(dirtyLed ? "flash" : null)"></span> Dirty</div>
+</div>
+
+<TinyMCEEditor @ref="editor"
+        OnInit="OnEditorInit"
+        Focused="OnEditorFocused"
+        ContentBlurred="OnEditorBlurred"
+        FirstChange="OnEditorDirty" />
 
 <div class="row mt-3">
     <div class="col">
@@ -47,11 +53,15 @@
         currentText = docA;
     }
 
-    private void SelectDoc(Doc doc)
+    private async Task SelectDoc(Doc doc)
     {
         SaveCurrent();
         currentDoc = doc;
         currentText = GetCurrent();
+        if (editor != null)
+        {
+            await editor.SetContentAsync(currentText);
+        }
     }
 
     private void SaveCurrent()
@@ -78,8 +88,41 @@
         _ => string.Empty
     };
 
-    private void OnContentChanged()
+    private TinyMCEEditor? editor;
+
+    private bool initLed;
+    private bool focusLed;
+    private bool blurLed;
+    private bool dirtyLed;
+
+    private async Task OnEditorInit()
     {
+        await FlashAsync(() => initLed = true, () => initLed = false);
+        if (editor != null)
+        {
+            await editor.SetContentAsync(currentText);
+        }
+    }
+
+    private Task OnEditorFocused()
+        => FlashAsync(() => focusLed = true, () => focusLed = false);
+
+    private async Task OnEditorBlurred(string html)
+    {
+        currentText = html;
         SaveCurrent();
+        await FlashAsync(() => blurLed = true, () => blurLed = false);
+    }
+
+    private Task OnEditorDirty()
+        => FlashAsync(() => dirtyLed = true, () => dirtyLed = false);
+
+    private async Task FlashAsync(Action setOn, Action setOff)
+    {
+        setOn();
+        await InvokeAsync(StateHasChanged);
+        await Task.Delay(500);
+        setOff();
+        await InvokeAsync(StateHasChanged);
     }
 }

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -163,3 +163,24 @@ code {
 .article-row {
     cursor: pointer;
 }
+
+/* Simple LED indicator */
+.led {
+    display: inline-block;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    background-color: #ccc;
+    margin-right: 4px;
+}
+
+.led.flash {
+    background-color: #28a745;
+    box-shadow: 0 0 6px #28a745;
+    animation: led-flash 0.5s ease-out;
+}
+
+@keyframes led-flash {
+    from { opacity: 1; }
+    to { opacity: 0.4; }
+}

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -137,6 +137,9 @@ window.getTinyEditorContentLength = function () {
 window.registerTinyEditorCallbacks = function (dotNetHelper) {
   if (window.tinymce && tinymce.get('articleEditor')) {
     const editor = tinymce.get('articleEditor');
+    editor.on('focus', function () {
+      dotNetHelper.invokeMethodAsync('OnEditorFocus');
+    });
     editor.on('blur', function () {
       dotNetHelper.invokeMethodAsync('OnEditorBlur');
     });


### PR DESCRIPTION
## Summary
- expose focus event from `TinyMCEEditor`
- show event LEDs in the editor demo and wire up focus/blur/dirty/init handlers
- support event callbacks in TinyMCE config script
- style LED indicator

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a843296dc8322ad2f1602488e7adc