### PR TITLE
Add TinyMCE event logging demo

### DIFF
--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -70,6 +70,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="events-demo">
+                <span class="bi bi-card-list" aria-hidden="true"></span> Events Demo
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="pcl-demo">
                 <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> PCL Demo
             </NavLink>

--- a/Pages/EventsDemo.razor
+++ b/Pages/EventsDemo.razor
@@ -1,0 +1,64 @@
+@page "/events-demo"
+@using TinyMCE.Blazor
+@implements IDisposable
+@inject IJSRuntime JS
+
+<h3>TinyMCE Events Demo</h3>
+
+<Editor Id="eventsEditor"
+        ScriptSrc="libman/tinymce/tinymce.min.js"
+        LicenseKey="gpl"
+        JsConfSrc="tinymceBlazorFullConfig"
+        @bind-Value="content" />
+
+<div class="mt-3">
+    <h5>Event Log</h5>
+    <div @ref="logDiv" class="log-window">
+        @foreach (var line in lines)
+        {
+            <div>@line</div>
+        }
+    </div>
+</div>
+
+@code {
+    private static event Action<string>? EventReceived;
+    private List<string> lines = new();
+    private string content = string.Empty;
+    private ElementReference logDiv;
+
+    protected override void OnInitialized()
+    {
+        EventReceived += HandleEvent;
+    }
+
+    private void HandleEvent(string line)
+    {
+        lines.Add(line);
+        InvokeAsync(async () =>
+        {
+            StateHasChanged();
+            await JS.InvokeVoidAsync("scrollLogToBottom", logDiv);
+        });
+    }
+
+    public void Dispose()
+    {
+        EventReceived -= HandleEvent;
+    }
+
+    [JSInvokable]
+    public static Task OnEditorEvent(string editorId, string eventName, string jsonPayload)
+    {
+        var payload = JsonSerializer.Deserialize<EditorEventPayload>(jsonPayload);
+        var line = $"[{DateTime.Now:HH:mm:ss}] {editorId} {eventName} (len={payload?.content?.Length ?? 0})";
+        EventReceived?.Invoke(line);
+        return Task.CompletedTask;
+    }
+
+    private class EditorEventPayload
+    {
+        public string? content { get; set; }
+        public object? args { get; set; }
+    }
+}

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -163,3 +163,13 @@ code {
 .article-row {
     cursor: pointer;
 }
+
+.log-window {
+    border: 1px solid #ccc;
+    height: 200px;
+    overflow-y: auto;
+    resize: both;
+    padding: 4px;
+    font-family: monospace;
+    white-space: pre-wrap;
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -42,6 +42,7 @@
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
     <script src="js/tinyMceConfig.js"></script>
+    <script src="js/tinyMceEventConfig.js"></script>
     <script src="js/infiniteScroll.js"></script>
 </body>
 

--- a/wwwroot/js/tinyMceEventConfig.js
+++ b/wwwroot/js/tinyMceEventConfig.js
@@ -1,0 +1,34 @@
+window.tinymceBlazorFullConfig = {
+  ...window.myTinyMceConfig,
+  setup: function (editor) {
+    if (window.myTinyMceConfig && typeof window.myTinyMceConfig.setup === 'function') {
+      window.myTinyMceConfig.setup(editor);
+    }
+    const allEvents = [
+      'Init','BeforeRenderUI','PostRenderUI','Focus','Blur',
+      'KeyDown','KeyUp','Click','DblClick','MouseDown','MouseUp',
+      'Paste','Cut','Copy','Undo','Redo','SaveContent','Change',
+      'Dirty','Submit','Resize','ExecCommand','NodeChange'
+    ];
+    allEvents.forEach(eventName => {
+      editor.on(eventName, e => {
+        DotNet.invokeMethodAsync(
+          'BlazorWP',
+          'OnEditorEvent',
+          editor.id,
+          eventName,
+          JSON.stringify({
+            content: editor.getContent(),
+            args: e
+          })
+        ).catch(err => console.error(err));
+      });
+    });
+  }
+};
+
+window.scrollLogToBottom = function(element) {
+  if (element) {
+    element.scrollTop = element.scrollHeight;
+  }
+};


### PR DESCRIPTION
## Summary
- add `EventsDemo` page to display TinyMCE events
- log events from TinyMCE via new `tinyMceEventConfig.js`
- add resizable log window style
- link new demo from nav menu

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8b0a6fb8832291c10fa3494a452e