### PR TITLE
Log TinyMCE events in demo

### DIFF
--- a/Components/TinyMCEEditor.razor
+++ b/Components/TinyMCEEditor.razor
@@ -19,6 +19,9 @@
     [Parameter]
     public EventCallback OnInit { get; set; }
 
+    [Parameter]
+    public EventCallback<string> EventReceived { get; set; }
+
     public bool IsReady { get; private set; }
 
     private DotNetObjectReference<TinyMCEEditor>? _objRef;
@@ -53,6 +56,10 @@
     [JSInvokable]
     public Task OnEditorDirty()
         => FirstChange.InvokeAsync();
+
+    [JSInvokable]
+    public Task OnEditorEvent(string type)
+        => EventReceived.InvokeAsync(type);
 
     public ValueTask DisposeAsync()
     {

--- a/Pages/EditDemo.razor
+++ b/Pages/EditDemo.razor
@@ -16,7 +16,8 @@
         LicenseKey="gpl"
         JsConfSrc="myTinyMceConfig"
         @bind-Value="currentText"
-        @bind-Value:after="OnContentChanged" />
+        @bind-Value:after="OnContentChanged"
+        EventReceived="LogEvent" />
 
 <div class="row mt-3">
     <div class="col">
@@ -32,6 +33,10 @@
         <textarea class="form-control" rows="5" readonly @bind="docC"></textarea>
     </div>
 </div>
+<div class="row mt-1">
+    @* use this textarea to display tinymce events *@
+    <textarea class="form-control" rows="5" readonly @bind="eventLog"></textarea>
+</div>
 
 @code {
     private enum Doc { A, B, C }
@@ -41,6 +46,7 @@
     private string docA = string.Empty;
     private string docB = string.Empty;
     private string docC = string.Empty;
+    private string eventLog = string.Empty;
 
     protected override void OnInitialized()
     {
@@ -81,5 +87,11 @@
     private void OnContentChanged()
     {
         SaveCurrent();
+    }
+
+    private void LogEvent(string ev)
+    {
+        eventLog = ($"{ev}\n" + eventLog).TrimEnd();
+        StateHasChanged();
     }
 }

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -145,5 +145,13 @@ window.registerTinyEditorCallbacks = function (dotNetHelper) {
       editor.off('change', changeHandler);
     };
     editor.on('change', changeHandler);
+
+    const originalFire = editor.fire;
+    editor.fire = function (type, data) {
+      try {
+        dotNetHelper.invokeMethodAsync('OnEditorEvent', type);
+      } catch (_) { }
+      return originalFire.call(this, type, data);
+    };
   }
 };


### PR DESCRIPTION
## Summary
- hook TinyMCE `fire` to forward all events to .NET
- expose `EventReceived` callback on `TinyMCEEditor`
- log events on the EditDemo page

## Testing
- `npm --version`
- `node --version`
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a8de39f348322bce4ad0daa555ccf