### PR TITLE
Switch edit demo to TinyMCEEditor wrapper

### DIFF
--- a/Pages/EditDemo.razor
+++ b/Pages/EditDemo.razor
@@ -1,22 +1,18 @@
 @page "/edit-demo"
-@using TinyMCE.Blazor
 
 <PageTitle>Edit Demo</PageTitle>
 
 <h1>Edit Demo</h1>
 
 <div class="mb-3">
-    <button class="btn btn-primary me-1" @onclick="() => SelectDoc(Doc.A)">Document A</button>
-    <button class="btn btn-primary me-1" @onclick="() => SelectDoc(Doc.B)">Document B</button>
-    <button class="btn btn-primary" @onclick="() => SelectDoc(Doc.C)">Document C</button>
+    <button class="btn btn-primary me-1" @onclick="() => SelectDocAsync(Doc.A)">Document A</button>
+    <button class="btn btn-primary me-1" @onclick="() => SelectDocAsync(Doc.B)">Document B</button>
+    <button class="btn btn-primary" @onclick="() => SelectDocAsync(Doc.C)">Document C</button>
 </div>
 
-<Editor Id="demoEditor"
-        ScriptSrc="libman/tinymce/tinymce.min.js"
-        LicenseKey="gpl"
-        JsConfSrc="myTinyMceConfig"
-        @bind-Value="currentText"
-        @bind-Value:after="OnContentChanged" />
+<TinyMCEEditor @ref="editor"
+               OnInit="HandleEditorReady"
+               ContentBlurred="OnEditorBlurred" />
 
 <div class="row mt-3">
     <div class="col">
@@ -37,6 +33,7 @@
     private enum Doc { A, B, C }
     private Doc currentDoc = Doc.A;
 
+    private TinyMCEEditor? editor;
     private string currentText = string.Empty;
     private string docA = string.Empty;
     private string docB = string.Empty;
@@ -47,11 +44,32 @@
         currentText = docA;
     }
 
-    private void SelectDoc(Doc doc)
+    private async Task HandleEditorReady()
     {
-        SaveCurrent();
+        if (editor != null)
+        {
+            await editor.SetContentAsync(currentText);
+        }
+    }
+
+    private async Task SelectDocAsync(Doc doc)
+    {
+        await SaveCurrentAsync();
         currentDoc = doc;
         currentText = GetCurrent();
+        if (editor != null)
+        {
+            await editor.SetContentAsync(currentText);
+        }
+    }
+
+    private async Task SaveCurrentAsync()
+    {
+        if (editor != null)
+        {
+            currentText = await editor.GetContentAsync();
+        }
+        SaveCurrent();
     }
 
     private void SaveCurrent()
@@ -78,8 +96,10 @@
         _ => string.Empty
     };
 
-    private void OnContentChanged()
+    private Task OnEditorBlurred(string html)
     {
+        currentText = html;
         SaveCurrent();
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
## Summary
- swap direct TinyMCE `<Editor>` component in `EditDemo` for the existing `TinyMCEEditor` wrapper
- load and save editor content via wrapper callbacks

## Testing
- `dotnet build BlazorWP.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a9ca63c6c832289c3a69ecafeb7db