### PR TITLE
Restore TinyMCE media library feature

### DIFF
--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -6,6 +6,7 @@ window.myTinyMceConfig = {
   resize: 'both',
   plugins: 'code media table fullscreen',
   toolbar: 'undo redo | bold italic | table | code mediaLibraryButton customButton showInfoButton fullscreen',
+  mediaSource: null,
   setup: function (editor) {
     // one-shot dynamic import, then hook all events
     import('./tinyMceHelper.js').then(m => m.hookEditorEvents(editor));
@@ -23,6 +24,129 @@ window.myTinyMceConfig = {
         alert(`Endpoint: ${endpoint}\nJWT: ${token}`);
       }
     });
-    // mediaLibraryButton, fetchMedia, etc. can remain as before
+
+    function openMediaDialog(items, totalPages) {
+      let page = 1;
+
+      function itemHtml(i) {
+        const thumb = (i.media_details && i.media_details.sizes && i.media_details.sizes.thumbnail)
+          ? i.media_details.sizes.thumbnail.source_url
+          : i.source_url;
+        const desc = encodeURIComponent(i.description && i.description.rendered ? i.description.rendered : `<img src="${i.source_url}" />`);
+        return `<img src="${thumb}" data-desc="${desc}" style="width:100px;height:100px;object-fit:cover;margin:4px;cursor:pointer;" />`;
+      }
+
+      const images = items.map(itemHtml).join('');
+
+      const html = `<div id="tiny-media-grid" style="display:flex;flex-wrap:wrap;">${images}</div>` +
+        `<div style="margin-top:8px;text-align:center;"><button type="button" id="tiny-media-loadmore">Add More</button></div>`;
+
+      const dlg = editor.windowManager.open({
+        title: 'Media Library',
+        size: 'large',
+        body: {
+          type: 'panel',
+          items: [{ type: 'htmlpanel', html: html }]
+        },
+        buttons: []
+      });
+
+      const panel = document.getElementById('tiny-media-grid');
+      panel.addEventListener('click', function (e) {
+        if (e.target.tagName === 'IMG') {
+          const html = decodeURIComponent(e.target.getAttribute('data-desc'));
+          editor.insertContent(html);
+          dlg.close();
+        }
+      });
+
+      const loadMoreBtn = document.getElementById('tiny-media-loadmore');
+      loadMoreBtn.addEventListener('click', async function () {
+        page++;
+        const result = await fetchMedia(page);
+        result.items.forEach(i => {
+          panel.insertAdjacentHTML('beforeend', itemHtml(i));
+        });
+        totalPages = result.totalPages;
+        if (page >= totalPages || result.items.length === 0) {
+          this.disabled = true;
+        }
+      });
+    }
+
+    function getMediaSource() {
+      return window.myTinyMceConfig.mediaSource;
+    }
+
+    async function fetchMedia(page = 1) {
+      const source = getMediaSource();
+      if (!source) {
+        alert('No media source selected');
+        return { items: [], totalPages: page };
+      }
+      const token = localStorage.getItem('jwtToken');
+      const url = source.replace(/\/?$/, '') + `/wp-json/wp/v2/media?per_page=100&page=${page}`;
+      try {
+        const res = await fetch(url, {
+          headers: token ? { 'Authorization': 'Bearer ' + token } : {}
+        });
+        if (!res.ok) {
+          alert('Failed to load media: ' + res.status);
+          return { items: [], totalPages: page };
+        }
+        const data = await res.json();
+        const totalPages = parseInt(res.headers.get('X-WP-TotalPages') || page);
+        return { items: data, totalPages };
+      } catch (err) {
+        alert('Error loading media: ' + err);
+        return { items: [], totalPages: page };
+      }
+    }
+
+    editor.ui.registry.addButton('mediaLibraryButton', {
+      text: 'Media',
+      onAction: async function () {
+        const result = await fetchMedia(1);
+        openMediaDialog(result.items, result.totalPages);
+      }
+    });
+  }
+};
+
+window.setTinyMediaSource = function (url) {
+  window.myTinyMceConfig.mediaSource = url || null;
+};
+
+window.setTinyEditorContent = function (html) {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    tinymce.get('articleEditor').setContent(html || '');
+  }
+};
+
+window.getTinyEditorContent = function () {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    return tinymce.get('articleEditor').getContent();
+  }
+  return '';
+};
+
+window.getTinyEditorContentLength = function () {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    return tinymce.get('articleEditor').getContent().length;
+  }
+  return 0;
+};
+
+window.registerTinyEditorCallbacks = function (dotNetHelper) {
+  if (window.tinymce && tinymce.get('articleEditor')) {
+    const editor = tinymce.get('articleEditor');
+    editor.on('blur', function () {
+      dotNetHelper.invokeMethodAsync('OnEditorBlur');
+    });
+    const changeHandler = function () {
+      dotNetHelper.invokeMethodAsync('OnEditorDirty');
+      editor.off('change', changeHandler);
+    };
+    editor.on('change', changeHandler);
   }
 };


### PR DESCRIPTION
## Summary
- restore the media library functions in `tinyMceConfig.js`
- keep dynamic event hookup and arrow functions

## Testing
- `dotnet build BlazorWP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b57b06df8832299e9b8004052958a