### PR TITLE
Remove read-only editor mode

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -127,7 +127,6 @@ public partial class Edit
         }
 
         showRetractReview = false;
-        isEditing = true;
         UpdateDirty();
         await InvokeAsync(StateHasChanged);
     }

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -154,13 +154,12 @@ public partial class Edit
         }
     }
 
-    private async Task OpenPost(PostSummary post, bool edit = false, bool forceReload = false)
+    private async Task OpenPost(PostSummary post, bool forceReload = false)
     {
         var sw = Stopwatch.StartNew();
         //Console.WriteLine($"[OpenPost] click id={post.Id}, title={post.Title}");
         if (post.Id == postId && !forceReload)
         {
-            isEditing = edit;
             sw.Stop();
             Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms (noop)");
             return;
@@ -201,23 +200,9 @@ public partial class Edit
         showRetractReview = post.Status == "pending";
         UpdateDirty();
         //Console.WriteLine($"[OpenPost] completed. postId={postId}");
-        isEditing = edit;
         await InvokeAsync(StateHasChanged);
         sw.Stop();
-        if (edit)
-        {
-            editTimerElapsedMs = sw.ElapsedMilliseconds;
-            editTimerPostId = post.Id;
-        }
-        else
-        {
-            Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms");
-        }
-    }
-
-    private async Task EditPost(PostSummary post)
-    {
-        await OpenPost(post, true, true);
+        Console.WriteLine($"[Perf] OpenPost({post.Id}) took {sw.ElapsedMilliseconds} ms");
     }
 
     private async Task RefreshPosts()

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -16,7 +16,6 @@ public partial class Edit
         lastSavedTitle = string.Empty;
         lastSavedContent = string.Empty;
         showRetractReview = false;
-        isEditing = false;
     }
 
     private Task SetEditorContentAsync(string html)

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -72,7 +72,6 @@ else if (showTable)
         <table class="table table-hover">
             <thead>
                 <tr>
-                    <th>Edit</th>
                     <th>Id</th>
                     <th>Title</th>
                     <th>Author</th>
@@ -85,9 +84,6 @@ else if (showTable)
                 @foreach (var p in DisplayPosts)
                 {
                     <tr @key="p.Id" class="article-row @(IsSelected(p, postId) ? "table-primary" : null)" @onclick="() => OpenPost(p)">
-                        <td>
-                            <button class="btn btn-sm btn-primary" @onclick="() => EditPost(p)" @onclick:stopPropagation="true">Edit</button>
-                        </td>
                         <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
                         <td>@p.Title</td>
                         <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
@@ -122,20 +118,11 @@ else if (showTable)
 
 
 
-@if (isEditing)
-{
-    <Editor
-        Id="mainEditor"
-        ScriptSrc="libman/tinymce/tinymce.min.js"
-        LicenseKey="gpl"
-        JsConfSrc="myTinyMceConfig"
-        @bind-Value="_content"
-        @bind-Value:after="UpdateDirty" />
-}
-else
-{
-    <div class="border p-2" @onclick="() => isEditing = true">
-        @((MarkupString)_content)
-    </div>
-}
+<Editor
+    Id="mainEditor"
+    ScriptSrc="libman/tinymce/tinymce.min.js"
+    LicenseKey="gpl"
+    JsConfSrc="myTinyMceConfig"
+    @bind-Value="_content"
+    @bind-Value:after="UpdateDirty" />
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -27,9 +27,6 @@ public partial class Edit : IAsyncDisposable
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;
-    private bool isEditing = false;
-    private int? editTimerPostId;
-    private long? editTimerElapsedMs;
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
     private string? baseUrl;


### PR DESCRIPTION
## Summary
- keep TinyMCE editor visible in `Edit` page
- simplify editor state management

## Testing
- `dotnet build -c Release` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685b5a8c4f54832294269e07be510488