### PR TITLE
Maintain loaded pages on refresh

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -208,14 +208,23 @@ public partial class Edit
     private async Task RefreshPosts()
     {
         //Console.WriteLine("[RefreshPosts] refreshing");
+        var pagesToLoad = currentPage;
         currentPage = 1;
         hasMore = true;
         await DisconnectScrollAsync();
         await LoadPosts(currentPage);
+
+        for (int p = 2; p <= pagesToLoad && hasMore; p++)
+        {
+            currentPage = p;
+            await LoadPosts(currentPage, append: true);
+        }
+
         if (postId != null && !posts.Any(p => p.Id == postId))
         {
             await LoadPostFromServerAsync(postId.Value);
         }
+
         await ObserveScrollAsync();
     }
 }


### PR DESCRIPTION
## Summary
- reload the same number of post pages on refresh

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_685b5d5616e08322989ec21e7e42eecd