### PR TITLE
Add SqlDemo page with EF Core SQLite demo

### DIFF
--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="AntDesign" Version="1.4.1.1" />
     <PackageReference Include="TinyMCE.Blazor" Version="2.1.0" />
     <PackageReference Include="WordPressPCL" Version="2.1.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.0" />
+    <PackageReference Include="SQLitePCLRaw.bundle_e_sqlite3" Version="2.1.5" />
   </ItemGroup>
 
 </Project>

--- a/Data/SqlDemoDbContext.cs
+++ b/Data/SqlDemoDbContext.cs
@@ -1,0 +1,20 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace BlazorWP;
+
+public class SqlDemoDbContext : DbContext
+{
+    public DbSet<DemoRecord> Records => Set<DemoRecord>();
+
+    public SqlDemoDbContext(DbContextOptions<SqlDemoDbContext> options)
+        : base(options)
+    {
+    }
+}
+
+public class DemoRecord
+{
+    public int Id { get; set; }
+    public string? Name { get; set; }
+    public int Value { get; set; }
+}

--- a/Data/SqlDemoSetup.cs
+++ b/Data/SqlDemoSetup.cs
@@ -1,0 +1,22 @@
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace BlazorWP;
+
+public static class SqlDemoSetup
+{
+    public static IServiceCollection AddSqlDemo(this IServiceCollection services)
+    {
+        var connection = new SqliteConnection("Data Source=sql-demo;Mode=Memory;Cache=Shared");
+        connection.Open();
+
+        services.AddSingleton(connection);
+        services.AddDbContextFactory<SqlDemoDbContext>(options => options.UseSqlite(connection));
+
+        using var context = new SqlDemoDbContext(new DbContextOptionsBuilder<SqlDemoDbContext>().UseSqlite(connection).Options);
+        context.Database.EnsureCreated();
+
+        return services;
+    }
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -69,6 +69,11 @@
                 <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> PCL Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="sql-demo">
+                <span class="bi bi-table-nav-menu" aria-hidden="true"></span> SQL Demo
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/SqlDemo.razor
+++ b/Pages/SqlDemo.razor
@@ -1,0 +1,79 @@
+@page "/sql-demo"
+@using Microsoft.EntityFrameworkCore
+@inject IDbContextFactory<SqlDemoDbContext> DbFactory
+
+<PageTitle>SQL Demo</PageTitle>
+
+<h1>SQL Demo</h1>
+
+<div class="mb-2">
+    <button class="btn btn-primary me-2" @onclick="AddRandomAsync">Add Random</button>
+    <button class="btn btn-secondary me-2" @onclick="AddRandomDelayedAsync">Add Random (Delayed)</button>
+    <button class="btn btn-warning" @onclick="AddConcurrentAsync">Add 5 Concurrent</button>
+</div>
+
+<div class="table-responsive" style="max-height:250px; overflow-y:auto;">
+    <table class="table table-striped">
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Name</th>
+                <th>Value</th>
+            </tr>
+        </thead>
+        <tbody>
+            @foreach (var rec in records)
+            {
+                <tr>
+                    <td>@rec.Id</td>
+                    <td>@rec.Name</td>
+                    <td>@rec.Value</td>
+                </tr>
+            }
+        </tbody>
+    </table>
+</div>
+
+@code {
+    private List<DemoRecord> records = new();
+    private readonly Random random = new();
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadAsync();
+    }
+
+    private async Task LoadAsync()
+    {
+        using var db = await DbFactory.CreateDbContextAsync();
+        records = await db.Records.OrderBy(r => r.Id).ToListAsync();
+    }
+
+    private async Task AddRandomAsync()
+    {
+        using var db = await DbFactory.CreateDbContextAsync();
+        db.Records.Add(new DemoRecord { Name = $"Item {random.Next(1000)}", Value = random.Next(1000) });
+        await db.SaveChangesAsync();
+        await LoadAsync();
+    }
+
+    private async Task AddRandomDelayedAsync()
+    {
+        await Task.Delay(random.Next(50, 300));
+        await AddRandomAsync();
+    }
+
+    private async Task AddConcurrentAsync()
+    {
+        var tasks = Enumerable.Range(0, 5).Select(async _ =>
+        {
+            await Task.Delay(random.Next(50, 300));
+            using var db = await DbFactory.CreateDbContextAsync();
+            db.Records.Add(new DemoRecord { Name = $"Item {random.Next(1000)}", Value = random.Next(1000) });
+            await db.SaveChangesAsync();
+        });
+
+        await Task.WhenAll(tasks);
+        await LoadAsync();
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -27,6 +27,7 @@ namespace BlazorWP
             builder.Services.AddPanoramicDataBlazor();
             builder.Services.AddAntDesign();
             builder.Services.AddScoped<JwtService>();
+            builder.Services.AddSqlDemo();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- add EF Core SQLite dependencies
- provide in-memory DB setup with `AddSqlDemo`
- register the demo database in Program
- create a SqlDemo page showing a scrollable table and concurrent add buttons
- link the new page in the nav menu

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8bf67a4483228591b33d05e97c93