### PR TITLE
Bind articles table to PDTable

### DIFF
--- a/Data/PostSummaryDataProvider.cs
+++ b/Data/PostSummaryDataProvider.cs
@@ -1,0 +1,54 @@
+using PanoramicData.Blazor.Interfaces;
+using PanoramicData.Blazor.Models;
+
+namespace BlazorWP.Data;
+
+public class PostSummaryDataProvider : IDataProviderService<Edit.PostSummary>
+{
+    private readonly Func<List<Edit.PostSummary>> _getItems;
+
+    public PostSummaryDataProvider(Func<List<Edit.PostSummary>> getItems)
+    {
+        _getItems = getItems;
+    }
+
+    public Task<DataResponse<Edit.PostSummary>> GetDataAsync(DataRequest<Edit.PostSummary> request, CancellationToken cancellationToken)
+    {
+        var items = _getItems();
+        return Task.FromResult(new DataResponse<Edit.PostSummary>(items, items.Count));
+    }
+
+    public Task<OperationResponse> DeleteAsync(Edit.PostSummary item, CancellationToken cancellationToken)
+    {
+        var items = _getItems();
+        var existing = items.FirstOrDefault(p => p.Id == item.Id);
+        if (existing != null)
+        {
+            items.Remove(existing);
+            return Task.FromResult(new OperationResponse { Success = true });
+        }
+        return Task.FromResult(new OperationResponse { ErrorMessage = "Item not found" });
+    }
+
+    public Task<OperationResponse> UpdateAsync(Edit.PostSummary item, IDictionary<string, object?> delta, CancellationToken cancellationToken)
+    {
+        var items = _getItems();
+        var existing = items.FirstOrDefault(p => p.Id == item.Id);
+        if (existing != null)
+        {
+            foreach (var kvp in delta)
+            {
+                var prop = typeof(Edit.PostSummary).GetProperty(kvp.Key);
+                prop?.SetValue(existing, kvp.Value);
+            }
+            return Task.FromResult(new OperationResponse { Success = true });
+        }
+        return Task.FromResult(new OperationResponse { ErrorMessage = "Item not found" });
+    }
+
+    public Task<OperationResponse> CreateAsync(Edit.PostSummary item, CancellationToken cancellationToken)
+    {
+        _getItems().Add(item);
+        return Task.FromResult(new OperationResponse { Success = true });
+    }
+}

--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -167,6 +167,10 @@ public partial class Edit
             if (placeholder != null)
             {
                 posts.Remove(placeholder);
+                if (postsTable != null)
+                {
+                    await postsTable.RefreshAsync();
+                }
             }
         }
         UpdateDirty();

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -88,6 +88,10 @@ public partial class Edit
                 await client.Posts.DeleteAsync(post.Id, true);
                 status = "Post moved to trash";
                 posts.Remove(post);
+                if (postsTable != null)
+                {
+                    await postsTable.RefreshAsync();
+                }
             }
             else
             {
@@ -95,6 +99,10 @@ public partial class Edit
                 await client.Posts.UpdateAsync(postUpdate);
                 status = $"Status changed to {newStatus}";
                 post.Status = newStatus;
+            }
+            if (postsTable != null)
+            {
+                await postsTable.RefreshAsync();
             }
             await InvokeAsync(StateHasChanged);
         }

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -62,6 +62,7 @@ public partial class Edit
             });
         }
         UpdateDirty();
+        postsProvider = new PostSummaryDataProvider(() => DisplayPosts.ToList());
         //Console.WriteLine("[OnInitializedAsync] completed");
     }
 

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -50,6 +50,10 @@ public partial class Edit
             }
             //Console.WriteLine($"[LoadPosts] loaded {count} posts");
             hasMore = count > 0;
+            if (postsTable != null)
+            {
+                await postsTable.RefreshAsync();
+            }
         }
         catch
         {
@@ -97,6 +101,10 @@ public partial class Edit
                     Date = null,
                     Content = _content
                 });
+                if (postsTable != null)
+                {
+                    await postsTable.RefreshAsync();
+                }
             }
             return true;
         }
@@ -136,6 +144,10 @@ public partial class Edit
                     Date = DateTime.SpecifyKind(post.DateGmt, DateTimeKind.Utc).ToLocalTime(),
                     Content = post.Content?.Rendered
                 });
+                if (postsTable != null)
+                {
+                    await postsTable.RefreshAsync();
+                }
             }
             else
             {
@@ -145,6 +157,10 @@ public partial class Edit
                 existing.Status = post.Status.ToString().ToLowerInvariant();
                 existing.Date = DateTime.SpecifyKind(post.DateGmt, DateTimeKind.Utc).ToLocalTime();
                 existing.Content = post.Content?.Rendered;
+                if (postsTable != null)
+                {
+                    await postsTable.RefreshAsync();
+                }
             }
         }
         catch (Exception ex)
@@ -225,6 +241,10 @@ public partial class Edit
             await LoadPostFromServerAsync(postId.Value);
         }
 
+        if (postsTable != null)
+        {
+            await postsTable.RefreshAsync();
+        }
         await ObserveScrollAsync();
     }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -69,48 +69,41 @@ else if (showTable)
         <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
     </div>
     <div class="table-scroll" @ref="scrollContainer">
-        <table class="table table-hover">
-            <thead>
-                <tr>
-                    <th>Id</th>
-                    <th>Title</th>
-                    <th>Author</th>
-                    <th>Status</th>
-                    <th>Publication Date</th>
-                    <th>Change Status</th>
-                </tr>
-            </thead>
-            <tbody>
-                @foreach (var p in DisplayPosts)
-                {
-                    <tr @key="p.Id" class="article-row @(IsSelected(p, postId) ? "table-primary" : null)" @onclick="() => OpenPost(p)">
-                        <td>@(p.Id > 0 ? p.Id.ToString() : "")</td>
-                        <td>@p.Title</td>
-                        <td>@(string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName)</td>
-                        <td>@p.Status</td>
-                        <td>@(p.Date.HasValue ? p.Date.Value.Humanize() : "")</td>
-                        <td>
-                            @if (p.Id > 0 && !string.IsNullOrEmpty(p.Status))
-                            {
-                                <div class="dropdown">
-                                    <button class="btn btn-sm @(GetStatusButtonClass(p.Status)) dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" @onclick:stopPropagation="true">
-                                        @p.Status
-                                    </button>
-                                    <ul class="dropdown-menu">
-                                        @foreach (var st in availableStatuses)
-                                        {
-                                            <li>
-                                                <button type="button" class="dropdown-item @(p.Status == st ? "active" : null)" @onclick="() => ChangeStatus(p, st)" @onclick:stopPropagation="true">@st</button>
-                                            </li>
-                                        }
-                                    </ul>
-                                </div>
-                            }
-                        </td>
-                    </tr>
-                }
-            </tbody>
-        </table>
+        <PDTable @ref="postsTable"
+                  TItem="PostSummary"
+                  DataProvider="postsProvider"
+                  KeyField="p => p.Id"
+                  TableClass="table table-hover">
+            <PDColumn TItem="PostSummary" Field="p => p.Id" Title="Id" />
+            <PDColumn TItem="PostSummary" Field="p => p.Title" Title="Title" />
+            <PDColumn TItem="PostSummary" Title="Author">
+                <Template Context="p">@((string.IsNullOrEmpty(p.AuthorName) ? (p.Author > 0 ? p.Author.ToString() : "") : p.AuthorName))</Template>
+            </PDColumn>
+            <PDColumn TItem="PostSummary" Field="p => p.Status" Title="Status" />
+            <PDColumn TItem="PostSummary" Title="Publication Date">
+                <Template Context="p">@(p.Date.HasValue ? p.Date.Value.Humanize() : "")</Template>
+            </PDColumn>
+            <PDColumn TItem="PostSummary" Sortable="false" Editable="false" Title="Change Status">
+                <Template Context="p">
+                    @if (p.Id > 0 && !string.IsNullOrEmpty(p.Status))
+                    {
+                        <div class="dropdown">
+                            <button class="btn btn-sm @(GetStatusButtonClass(p.Status)) dropdown-toggle" type="button" data-bs-toggle="dropdown" aria-expanded="false" @onclick:stopPropagation="true">
+                                @p.Status
+                            </button>
+                            <ul class="dropdown-menu">
+                                @foreach (var st in availableStatuses)
+                                {
+                                    <li>
+                                        <button type="button" class="dropdown-item @(p.Status == st ? "active" : null)" @onclick="() => ChangeStatus(p, st)" @onclick:stopPropagation="true">@st</button>
+                                    </li>
+                                }
+                            </ul>
+                        </div>
+                    }
+                </Template>
+            </PDColumn>
+        </PDTable>
         <div @ref="scrollAnchor" class="scroll-anchor"></div>
     </div>
 }

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -3,6 +3,8 @@ using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
+using PanoramicData.Blazor;
+using BlazorWP.Data;
 
 namespace BlazorWP.Pages;
 
@@ -31,6 +33,8 @@ public partial class Edit : IAsyncDisposable
     private WordPressClient? client;
     private string? baseUrl;
     private int? postId;
+    private PDTable<PostSummary>? postsTable;
+    private PostSummaryDataProvider? postsProvider;
 
     private IEnumerable<PostSummary> DisplayPosts
     {


### PR DESCRIPTION
## Summary
- add `PostSummaryDataProvider` for PDTable
- replace raw posts table with PDTable
- refresh PDTable when posts change
- wire up provider on initialization

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8df57a808322a1a4d1810c05c976