### PR TITLE
Add refresh limit for posts

### DIFF
--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -48,7 +48,11 @@ public partial class Edit
         await SetupWordPressClientAsync();
         currentPage = 1;
         hasMore = true;
-        await LoadPosts(currentPage);
+        if (!int.TryParse(selectedRefreshCount, out var initCount))
+        {
+            initCount = 10;
+        }
+        await LoadPosts(currentPage, perPageOverride: initCount);
         if (postId != null && !posts.Any(p => p.Id == postId))
         {
             posts.Add(new PostSummary

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -67,6 +67,15 @@ else if (showTable)
         <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @bind:after="OnShowTrashedChanged" />
         <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
     </div>
+    <div class="d-flex align-items-center mb-2">
+        <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts">Refresh</button>
+        <select class="form-select form-select-sm w-auto" @bind="selectedRefreshCount">
+            @foreach (var opt in refreshOptions)
+            {
+                <option value="@opt">@opt</option>
+            }
+        </select>
+    </div>
     <div class="table-scroll">
         <table class="table table-hover">
             <thead>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -27,6 +27,8 @@ public partial class Edit : IAsyncDisposable
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;
+    private string selectedRefreshCount = "10";
+    private readonly string[] refreshOptions = new[] { "10", "25", "50", "100", "all" };
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
     private WordPressClient? client;
     private string? baseUrl;


### PR DESCRIPTION
## Summary
- add dropdown of refresh sizes and button in Edit page
- implement refresh logic to load selected number of posts
- load posts with selected size on initialization

## Testing
- `dotnet build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bab2e5f188322957573fca85e2e2c