### PR TITLE
Disable Refresh button while posts load

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -207,6 +207,8 @@ public partial class Edit
 
     private async Task RefreshPosts()
     {
+        if (isLoading) return;
+        isLoading = true;
         currentPage = 1;
         hasMore = true;
 
@@ -233,6 +235,7 @@ public partial class Edit
             }
             await LoadPosts(1, append: false, perPageOverride: count);
         }
+        isLoading = false;
     }
 
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -54,7 +54,7 @@
         <div class="ms-auto d-flex align-items-center">
 
     <div class="d-flex align-items-center mb-2">
-        <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts">Refresh</button>
+        <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts" disabled="@isLoading">Refresh</button>
         <select class="form-select form-select-sm w-auto" @bind="selectedRefreshCount">
             @foreach (var opt in refreshOptions)
             {


### PR DESCRIPTION
## Summary
- disable the Refresh button while posts are being fetched
- ensure RefreshPosts sets the loading flag

## Testing
- `dotnet build BlazorWP.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb64b284c8322bcb59e63e0764fe7