### PR TITLE
Add article count indicator

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -61,6 +61,7 @@
                 <option value="@opt">@opt</option>
             }
         </select>
+        <span class="ms-2">@DisplayCount articles</span>
     </div>
             <span><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
         </div>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -57,6 +57,8 @@ public partial class Edit : IAsyncDisposable
         }
     }
 
+    private int DisplayCount => DisplayPosts.Count();
+
     private static bool IsSelected(PostSummary post, int? selectedId)
     {
         return selectedId == null ? post.Id == -1 : post.Id == selectedId;


### PR DESCRIPTION
## Summary
- show number of displayed articles next to Refresh

## Testing
- `dotnet build --no-restore` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb9b900088322a6e00cf1b052cd39