### PR TITLE
Move trash filter to query and reposition toggle

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -62,6 +62,7 @@ public partial class Edit
     private async Task OnShowTrashedChanged()
     {
         await JS.InvokeVoidAsync("localStorage.setItem", ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
+        await RefreshPosts();
     }
 
     private async Task ChangeStatus(PostSummary post, string newStatus)

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -21,13 +21,26 @@ public partial class Edit
             return;
         }
 
+        var statuses = new List<Status>
+        {
+            Status.Publish,
+            Status.Private,
+            Status.Draft,
+            Status.Pending,
+            Status.Future
+        };
+        if (showTrashed)
+        {
+            statuses.Add(Status.Trash);
+        }
+
         var qb = new PostsQueryBuilder
         {
             Context = Context.Edit,
             Page = page,
             PerPage = perPageOverride ?? (page == 1 && !append ? 10 : 20),
             Embed = true,
-            Statuses = new List<Status> { Status.Publish, Status.Private, Status.Draft, Status.Pending, Status.Future, Status.Trash }
+            Statuses = statuses
         };
 
         try

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -55,12 +55,16 @@
 
     <div class="d-flex align-items-center mb-2">
         <button class="btn btn-sm btn-outline-secondary me-2" @onclick="RefreshPosts" disabled="@isLoading">Refresh</button>
-        <select class="form-select form-select-sm w-auto" @bind="selectedRefreshCount">
+        <select class="form-select form-select-sm w-auto me-2" @bind="selectedRefreshCount">
             @foreach (var opt in refreshOptions)
             {
                 <option value="@opt">@opt</option>
             }
         </select>
+        <div class="form-check form-switch me-2">
+            <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @bind:after="OnShowTrashedChanged" />
+            <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
+        </div>
         <span class="ms-2">@DisplayCount articles</span>
     </div>
             <span><strong>Status:</strong> @(isDirty ? "Dirty" : "Clean")</span>
@@ -74,10 +78,6 @@
 }
 else if (showTable)
 {
-    <div class="form-check form-switch mb-2">
-        <input class="form-check-input" type="checkbox" id="showTrashedToggle" @bind="showTrashed" @bind:after="OnShowTrashedChanged" />
-        <label class="form-check-label" for="showTrashedToggle">Include trashed articles</label>
-    </div>
     <div class="table-scroll">
         <table class="table table-hover">
             <thead>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -40,11 +40,6 @@ public partial class Edit : IAsyncDisposable
         {
             IEnumerable<PostSummary> query = posts.OrderByDescending(p => p.Id);
 
-            if (!showTrashed)
-            {
-                query = query.Where(p => !string.Equals(p.Status, "trash", StringComparison.OrdinalIgnoreCase));
-            }
-
             if (postId == null)
             {
                 var title = string.IsNullOrWhiteSpace(postTitle)


### PR DESCRIPTION
## Summary
- move Include trashed articles checkbox next to the Refresh button
- refresh posts when Include trashed articles changes
- filter trash at query time instead of just hiding in the UI

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbc2ec3288322be83c45ce14c9c2b