### PR TITLE
Fix trashed toggle refresh behavior

### DIFF
--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -62,7 +62,8 @@ public partial class Edit
     private async Task OnShowTrashedChanged()
     {
         await JS.InvokeVoidAsync("localStorage.setItem", ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
-        await RefreshPosts();
+        // Only update the stored preference. Actual querying happens when
+        // the user explicitly clicks the Refresh button.
     }
 
     private async Task ChangeStatus(PostSummary post, string newStatus)


### PR DESCRIPTION
## Summary
- avoid refreshing posts when toggling "Include trashed articles"

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bbf8cb7648322aca24d5d722990aa