### PR TITLE
Conditionally show Save Draft button

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -44,7 +44,10 @@
 
     <div class="d-flex align-items-center mb-2">
         <button class="btn btn-success me-2" @onclick="NewPost">New</button>
-        <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
+        @if (ShowSaveDraftButton)
+        {
+            <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
+        }
         <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
         @if (showRetractReview)
         {

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -54,6 +54,19 @@ public partial class Edit : IAsyncDisposable
 
     private int DisplayCount => DisplayPosts.Count();
 
+    private string? CurrentPostStatus
+    {
+        get
+        {
+            return postId.HasValue
+                ? posts.FirstOrDefault(p => p.Id == postId.Value)?.Status
+                : null;
+        }
+    }
+
+    private bool ShowSaveDraftButton
+        => postId == null || string.Equals(CurrentPostStatus, "draft", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(CurrentPostStatus);
+
     private static bool IsSelected(PostSummary post, int? selectedId)
     {
         return selectedId == null ? post.Id == -1 : post.Id == selectedId;


### PR DESCRIPTION
## Summary
- add helper to track current post status
- show Save Draft button only when post is new or draft

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bc7b899b88322b31eba4c722e3aef