### PR TITLE
Improve draft saving UX

### DIFF
--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -33,10 +33,12 @@ public partial class Edit
             _content = latestDraft.Content ?? string.Empty;
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            hasPersistedContent = true;
         }
         else
         {
             ResetEditorState();
+            hasPersistedContent = false;
         }
 
         var trashedSetting = await JS.InvokeAsync<string?>("localStorage.getItem", ShowTrashedKey);

--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -111,9 +111,11 @@ public partial class Edit
                     Content = _content
                 });
             }
+            hasPersistedContent = true;
             return true;
         }
         //Console.WriteLine("[TryLoadDraftAsync] no draft found");
+        hasPersistedContent = false;
         return false;
     }
 
@@ -136,6 +138,7 @@ public partial class Edit
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
             await SetEditorContentAsync(_content);
+            hasPersistedContent = false;
             var existing = posts.FirstOrDefault(p => p.Id == id);
             if (existing == null)
             {

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -16,6 +16,7 @@ public partial class Edit
         lastSavedTitle = string.Empty;
         lastSavedContent = string.Empty;
         showRetractReview = false;
+        hasPersistedContent = false;
     }
 
     private Task SetEditorContentAsync(string html)

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -46,7 +46,7 @@
         <button class="btn btn-success me-2" @onclick="NewPost">New</button>
         @if (ShowSaveDraftButton)
         {
-            <button class="btn btn-primary me-2" @onclick="SaveDraft">Save Draft</button>
+            <button class="btn btn-primary me-2" @onclick="SaveDraft" disabled="@(!CanSaveDraft)">Save Draft</button>
         }
         <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
         @if (showRetractReview)

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -27,6 +27,7 @@ public partial class Edit : IAsyncDisposable
     private bool showControls = true;
     private bool showTable = true;
     private bool showTrashed = false;
+    private bool hasPersistedContent = false;
     private string selectedRefreshCount = "10";
     private readonly string[] refreshOptions = new[] { "10", "25", "50", "100", "all" };
     private readonly string[] availableStatuses = new[] { "draft", "pending", "publish", "private", "trash" };
@@ -66,6 +67,8 @@ public partial class Edit : IAsyncDisposable
 
     private bool ShowSaveDraftButton
         => postId == null || string.Equals(CurrentPostStatus, "draft", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(CurrentPostStatus);
+
+    private bool CanSaveDraft => isDirty && hasPersistedContent;
 
     private static bool IsSelected(PostSummary post, int? selectedId)
     {


### PR DESCRIPTION
## Summary
- disable Save Draft unless there are unsaved changes and a local draft exists
- clear persisted draft after a successful save
- track persisted draft state during lifecycle and editor events

## Testing
- `dotnet build -c Release` *(fails: command not found)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bca5432a08322a79b2a262eb5addc