### PR TITLE
Remove unused placeholder row in editor

### DIFF
--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -35,23 +35,8 @@ public partial class Edit : IAsyncDisposable
     private string? baseUrl;
     private int? postId;
 
-    private IEnumerable<PostSummary> DisplayPosts
-    {
-        get
-        {
-            IEnumerable<PostSummary> query = posts.OrderByDescending(p => p.Id);
-
-            if (postId == null)
-            {
-                var title = string.IsNullOrWhiteSpace(postTitle)
-                    ? "(Not saved yet)"
-                    : $"{postTitle} (not saved yet)";
-                return new[] { new PostSummary { Id = -1, Title = title, Author = 0, AuthorName = string.Empty } }.Concat(query);
-            }
-
-            return query;
-        }
-    }
+    private IEnumerable<PostSummary> DisplayPosts =>
+        posts.OrderByDescending(p => p.Id);
 
     private int DisplayCount => DisplayPosts.Count();
 
@@ -72,7 +57,7 @@ public partial class Edit : IAsyncDisposable
 
     private static bool IsSelected(PostSummary post, int? selectedId)
     {
-        return selectedId == null ? post.Id == -1 : post.Id == selectedId;
+        return selectedId != null && post.Id == selectedId;
     }
 
     private class DraftInfo


### PR DESCRIPTION
## Summary
- show only existing posts in the editor
- remove logic that highlighted the `(Not saved yet)` row

## Testing
- `dotnet build BlazorWP.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd30341c883229ac007c9e7969ad0