### PR TITLE
Update editor post refresh after save

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -60,6 +60,11 @@ public partial class Edit
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
             await RemoveLocalDraftAsync(postId);
+            if (postId != null)
+            {
+                await LoadPostFromServerAsync(postId.Value);
+                await InvokeAsync(StateHasChanged);
+            }
         }
         else
         {
@@ -121,6 +126,11 @@ public partial class Edit
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
             await RemoveLocalDraftAsync(postId);
+            if (postId != null)
+            {
+                await LoadPostFromServerAsync(postId.Value);
+                await InvokeAsync(StateHasChanged);
+            }
         }
         else
         {
@@ -158,6 +168,8 @@ public partial class Edit
             currentPage = 1;
             hasMore = true;
             await LoadPosts(currentPage);
+            await LoadPostFromServerAsync(postId.Value);
+            await InvokeAsync(StateHasChanged);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- refresh post data after saving or changing post status in Edit page

## Testing
- `dotnet build BlazorWP.sln -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bd656d53883229d1b867d60bedd0f