### PR TITLE
Show Submit For Review button only on drafts

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -48,7 +48,10 @@
         {
             <button class="btn btn-primary me-2" @onclick="SaveDraft" disabled="@(!CanSaveDraft)">Save Draft</button>
         }
-        <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
+        @if (ShowSubmitForReviewButton)
+        {
+            <button class="btn btn-secondary me-2" @onclick="SubmitForReview">Submit for Review</button>
+        }
         @if (showRetractReview)
         {
             <button class="btn btn-warning me-2" @onclick="RetractReview">Retract Review</button>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -53,6 +53,9 @@ public partial class Edit : IAsyncDisposable
     private bool ShowSaveDraftButton
         => postId == null || string.Equals(CurrentPostStatus, "draft", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(CurrentPostStatus);
 
+    private bool ShowSubmitForReviewButton
+        => postId == null || string.Equals(CurrentPostStatus, "draft", StringComparison.OrdinalIgnoreCase) || string.IsNullOrEmpty(CurrentPostStatus);
+
     private bool CanSaveDraft => isDirty || hasPersistedContent;
 
     private static bool IsSelected(PostSummary post, int? selectedId)


### PR DESCRIPTION
## Summary
- only display "Submit for Review" when current article is a draft

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bdf9b0d808322931082067eea2231