### PR TITLE
Improve edit page layout

### DIFF
--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -82,6 +82,7 @@ public partial class Edit
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
             }
+            await JS.InvokeVoidAsync("initEditSplit");
             StateHasChanged();
         }
     }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -78,19 +78,21 @@
     </div>
 }
 
-@if (posts == null)
-{
-    <p><em>Loading posts...</em></p>
-}
-else if (showTable)
-{
-    <div class="table-scroll">
-        <table class="table table-hover">
-            <thead>
-                <tr>
-                    <th>Id</th>
-                    <th>Title</th>
-                    <th>Author</th>
+<div id="editSplit" class="edit-split">
+    <div class="article-list @(showTable ? string.Empty : "d-none")">
+        @if (posts == null)
+        {
+            <p><em>Loading posts...</em></p>
+        }
+        else
+        {
+            <div class="table-scroll">
+                <table class="table table-hover">
+                    <thead>
+                        <tr>
+                            <th>Id</th>
+                            <th>Title</th>
+                            <th>Author</th>
                     <th>Status</th>
                     <th>Publication Date</th>
                     <th>Change Status</th>
@@ -126,18 +128,19 @@ else if (showTable)
                     </tr>
                 }
             </tbody>
-        </table>
+                </table>
+            </div>
+        }
     </div>
-}
-
-
-
-
-<Editor
-    Id="mainEditor"
-    ScriptSrc="libman/tinymce/tinymce.min.js"
-    LicenseKey="gpl"
-    JsConfSrc="myTinyMceConfig"
-    @bind-Value="_content"
-    @bind-Value:after="UpdateDirty" />
+    <div class="splitter @(showTable ? string.Empty : "d-none")"></div>
+    <div class="editor-pane">
+        <Editor
+            Id="mainEditor"
+            ScriptSrc="libman/tinymce/tinymce.min.js"
+            LicenseKey="gpl"
+            JsConfSrc="myTinyMceConfig"
+            @bind-Value="_content"
+            @bind-Value:after="UpdateDirty" />
+    </div>
+</div>
 

--- a/Pages/Edit.razor.css
+++ b/Pages/Edit.razor.css
@@ -1,0 +1,15 @@
+.edit-split {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 10rem);
+}
+
+.article-list {
+    overflow-y: auto;
+}
+
+.splitter {
+    height: 6px;
+    background-color: #dee2e6;
+    cursor: row-resize;
+}

--- a/wwwroot/css/app.css
+++ b/wwwroot/css/app.css
@@ -151,9 +151,7 @@ code {
 }
 
 .table-scroll {
-    height: 300px;
     overflow-y: auto;
-    resize: vertical;
 }
 
 

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -42,6 +42,7 @@
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
     <script src="js/tinyMceConfig.js"></script>
+    <script src="js/editSplit.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/editSplit.js
+++ b/wwwroot/js/editSplit.js
@@ -1,0 +1,36 @@
+window.initEditSplit = function () {
+  const container = document.getElementById('editSplit');
+  if (!container) return;
+  const topPane = container.querySelector('.article-list');
+  const splitter = container.querySelector('.splitter');
+  let dragging = false;
+  let startY = 0;
+  let startHeight = 0;
+
+  splitter.addEventListener('mousedown', function (e) {
+    dragging = true;
+    startY = e.clientY;
+    startHeight = topPane.offsetHeight;
+    document.body.style.cursor = 'row-resize';
+    e.preventDefault();
+  });
+
+  document.addEventListener('mousemove', function (e) {
+    if (!dragging) return;
+    const delta = e.clientY - startY;
+    const containerRect = container.getBoundingClientRect();
+    let newHeight = startHeight + delta;
+    const min = 100;
+    const max = containerRect.height - min;
+    if (newHeight < min) newHeight = min;
+    if (newHeight > max) newHeight = max;
+    topPane.style.height = newHeight + 'px';
+  });
+
+  document.addEventListener('mouseup', function () {
+    if (dragging) {
+      dragging = false;
+      document.body.style.cursor = '';
+    }
+  });
+};

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -3,7 +3,7 @@ window.myTinyMceConfig = {
   promotion: false,
   branding: false,
   statusbar: true,
-  resize: 'both',
+  resize: false,
   plugins: 'code media table fullscreen',
   toolbar: 'undo redo | bold italic | table | code mediaLibraryButton customButton showInfoButton fullscreen',
   mediaSource: null,


### PR DESCRIPTION
## Summary
- create page-level CSS for editor split view
- keep table and editor inside a resizable split container
- disable TinyMCE resizing and remove table resize CSS
- add JS helper to adjust split divider
- hook new script on page load

## Testing
- `dotnet build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685be78034cc83228f5f19f36e3e6bc0