### PR TITLE
Add categories editing to post editor

### DIFF
--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -1,5 +1,7 @@
 using System.Text.Json;
 using Microsoft.JSInterop;
+using System.Collections.Generic;
+using System.Linq;
 using WordPressPCL;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
@@ -30,7 +32,8 @@ public partial class Edit
                 {
                     Title = new Title(title),
                     Content = new Content(_content),
-                    Status = Status.Draft
+                    Status = Status.Draft,
+                    Categories = selectedCategoryIds.ToList()
                 };
                 var created = await client.Posts.CreateAsync(post);
                 postId = created.Id;
@@ -43,7 +46,8 @@ public partial class Edit
                     Id = postId.Value,
                     Title = new Title(title),
                     Content = new Content(_content),
-                    Status = Status.Draft
+                    Status = Status.Draft,
+                    Categories = selectedCategoryIds.ToList()
                 };
                 await client.Posts.UpdateAsync(post);
                 status = "Draft updated";
@@ -59,6 +63,7 @@ public partial class Edit
         {
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            lastSavedCategoryIds = selectedCategoryIds.ToHashSet();
             await RemoveLocalDraftAsync(postId);
             if (postId != null)
             {
@@ -96,7 +101,8 @@ public partial class Edit
                 {
                     Title = new Title(title),
                     Content = new Content(_content),
-                    Status = Status.Pending
+                    Status = Status.Pending,
+                    Categories = selectedCategoryIds.ToList()
                 };
                 var created = await client.Posts.CreateAsync(post);
                 postId = created.Id;
@@ -109,7 +115,8 @@ public partial class Edit
                     Id = postId.Value,
                     Title = new Title(title),
                     Content = new Content(_content),
-                    Status = Status.Pending
+                    Status = Status.Pending,
+                    Categories = selectedCategoryIds.ToList()
                 };
                 await client.Posts.UpdateAsync(post);
                 status = "Updated and submitted for review";
@@ -125,6 +132,7 @@ public partial class Edit
         {
             lastSavedTitle = postTitle;
             lastSavedContent = _content;
+            lastSavedCategoryIds = selectedCategoryIds.ToHashSet();
             await RemoveLocalDraftAsync(postId);
             if (postId != null)
             {
@@ -209,6 +217,7 @@ public partial class Edit
         }
         existing.Title = postTitle;
         existing.Content = _content;
+        existing.Categories = selectedCategoryIds.ToList();
         existing.LastUpdated = DateTime.UtcNow;
         list = list.OrderByDescending(d => d.LastUpdated).Take(3).ToList();
         await SaveDraftStatesAsync(list);

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -1,5 +1,8 @@
 using System.Text.Json;
 using Microsoft.JSInterop;
+using Microsoft.AspNetCore.Components;
+using System.Collections.Generic;
+using System.Linq;
 using WordPressPCL;
 using WordPressPCL.Models;
 using WordPressPCL.Utility;
@@ -44,7 +47,9 @@ public partial class Edit
 
     private void UpdateDirty()
     {
-        isDirty = postTitle != lastSavedTitle || _content != lastSavedContent;
+        isDirty = postTitle != lastSavedTitle ||
+            _content != lastSavedContent ||
+            !selectedCategoryIds.SetEquals(lastSavedCategoryIds);
         //Console.WriteLine($"[UpdateDirty] isDirty={isDirty}");
     }
 
@@ -64,6 +69,20 @@ public partial class Edit
         await JS.InvokeVoidAsync("localStorage.setItem", ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
         // Only update the stored preference. Actual querying happens when
         // the user explicitly clicks the Refresh button.
+    }
+
+    private void OnCategoryCheckboxChanged(int id, ChangeEventArgs e)
+    {
+        var isChecked = e.Value as bool? == true;
+        if (isChecked)
+        {
+            selectedCategoryIds.Add(id);
+        }
+        else
+        {
+            selectedCategoryIds.Remove(id);
+        }
+        UpdateDirty();
     }
 
     private async Task ChangeStatus(PostSummary post, string newStatus)

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Linq;
+using System.Collections.Generic;
 using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
@@ -48,6 +50,15 @@ public partial class Edit
         }
 
         await SetupWordPressClientAsync();
+        if (client != null)
+        {
+            try
+            {
+                var list = await client.Categories.GetAllAsync();
+                categories = list?.ToList() ?? new List<Category>();
+            }
+            catch { }
+        }
         currentPage = 1;
         hasMore = true;
         if (!int.TryParse(selectedRefreshCount, out var initCount))
@@ -81,6 +92,15 @@ public partial class Edit
             if (!string.IsNullOrEmpty(selectedMediaSource))
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
+            }
+            if (client != null)
+            {
+                try
+                {
+                    var list = await client.Categories.GetAllAsync();
+                    categories = list?.ToList() ?? new List<Category>();
+                }
+                catch { }
             }
             StateHasChanged();
         }

--- a/Pages/Edit.State.cs
+++ b/Pages/Edit.State.cs
@@ -17,6 +17,8 @@ public partial class Edit
         lastSavedContent = string.Empty;
         showRetractReview = false;
         hasPersistedContent = false;
+        selectedCategoryIds.Clear();
+        lastSavedCategoryIds.Clear();
     }
 
     private Task SetEditorContentAsync(string html)

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -41,6 +41,21 @@
             </select>
         </div>
     }
+    @if (categories.Any())
+    {
+        <div class="mb-3">
+            <label class="form-label">Categories</label>
+            <div>
+                @foreach (var cat in categories)
+                {
+                    <div class="form-check form-check-inline">
+                        <input class="form-check-input" type="checkbox" id="cat-@cat.Id" checked="@selectedCategoryIds.Contains(cat.Id)" @onchange="e => OnCategoryCheckboxChanged(cat.Id, e)" />
+                        <label class="form-check-label" for="cat-@cat.Id">@cat.Name</label>
+                    </div>
+                }
+            </div>
+        </div>
+    }
 
     <div class="d-flex align-items-center mb-2">
         <button class="btn btn-success me-2" @onclick="NewPost">New</button>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -1,4 +1,6 @@
 using System.Text.Json;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
@@ -19,6 +21,9 @@ public partial class Edit : IAsyncDisposable
     private bool showRetractReview = false;
     private List<string> mediaSources = new();
     private string? selectedMediaSource;
+    private List<Category> categories = new();
+    private HashSet<int> selectedCategoryIds = new();
+    private HashSet<int> lastSavedCategoryIds = new();
     private List<PostSummary> posts = new();
     private bool hasMore = true;
     private int currentPage = 1;
@@ -68,6 +73,7 @@ public partial class Edit : IAsyncDisposable
         public int? PostId { get; set; }
         public string? Title { get; set; }
         public string? Content { get; set; }
+        public List<int> Categories { get; set; } = new();
         public DateTime LastUpdated { get; set; }
     }
 
@@ -80,6 +86,7 @@ public partial class Edit : IAsyncDisposable
         public string? Status { get; set; }
         public DateTime? Date { get; set; }
         public string? Content { get; set; }
+        public List<int> CategoryIds { get; set; } = new();
     }
 
 


### PR DESCRIPTION
## Summary
- add categories data to editor component state
- save categories in local and remote posts
- load WordPress categories and display them as checkboxes
- update dirty-check logic to detect category changes

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685beef02b848322aa867381aa9521ac