### PR TITLE
Make editor read-only when article not draft

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -153,6 +153,7 @@ else if (showTable)
     ScriptSrc="libman/tinymce/tinymce.min.js"
     LicenseKey="gpl"
     JsConfSrc="myTinyMceConfig"
+    Readonly="@EditorReadOnly"
     @bind-Value="_content"
     @bind-Value:after="UpdateDirty" />
 

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -63,6 +63,8 @@ public partial class Edit : IAsyncDisposable
 
     private bool CanSaveDraft => isDirty || hasPersistedContent;
 
+    private bool EditorReadOnly => !ShowSaveDraftButton;
+
     private static bool IsSelected(PostSummary post, int? selectedId)
     {
         return selectedId != null && post.Id == selectedId;


### PR DESCRIPTION
## Summary
- disable editing for non-draft posts

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bfa64178c832284d3bc71e9615e61