### PR TITLE
Disable categories when editing non-draft

### DIFF
--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -49,7 +49,7 @@
                 @foreach (var cat in categories)
                 {
                     <div class="form-check form-check-inline">
-                        <input class="form-check-input" type="checkbox" id="cat-@cat.Id" checked="@selectedCategoryIds.Contains(cat.Id)" @onchange="e => OnCategoryCheckboxChanged(cat.Id, e)" />
+                        <input class="form-check-input" type="checkbox" id="cat-@cat.Id" checked="@selectedCategoryIds.Contains(cat.Id)" @onchange="e => OnCategoryCheckboxChanged(cat.Id, e)" disabled="@EditorReadOnly" />
                         <label class="form-check-label" for="cat-@cat.Id">@cat.Name</label>
                     </div>
                 }


### PR DESCRIPTION
## Summary
- disable category checkboxes when the post can't be saved

## Testing
- `dotnet build BlazorWP.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bff2490f88322925800788c182ca9