### PR TITLE
Ensure posts load in descending date order

### DIFF
--- a/Pages/Edit.Posts.cs
+++ b/Pages/Edit.Posts.cs
@@ -42,7 +42,9 @@ public partial class Edit
             Page = page,
             PerPage = perPageOverride ?? (page == 1 && !append ? 10 : 20),
             Embed = true,
-            Statuses = statuses
+            Statuses = statuses,
+            OrderBy = PostsOrderBy.Date,
+            Order = Order.DESC
         };
 
         try

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -41,7 +41,9 @@ public partial class Edit : IAsyncDisposable
     private int? postId;
 
     private IEnumerable<PostSummary> DisplayPosts =>
-        posts.OrderByDescending(p => p.Id);
+        posts
+            .OrderByDescending(p => p.Date ?? DateTime.MinValue)
+            .ThenByDescending(p => p.Id);
 
     private int DisplayCount => DisplayPosts.Count();
 


### PR DESCRIPTION
## Summary
- ensure WordPress queries request posts ordered by newest first
- sort the post list by most recent when displaying

## Testing
- `dotnet build -v minimal` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bfe7eab4c832281faec953a49e8db