### PR TITLE
Add persistent WP-host toggle in top bar

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -19,6 +19,10 @@
             {
                 <span class="ms-2">@currentUsername</span>
             }
+            <div class="form-check form-switch ms-2">
+                <input class="form-check-input" type="checkbox" id="hostInWpToggle" @bind="hostInWp" @bind:after="OnHostInWpChanged" />
+                <label class="form-check-label" for="hostInWpToggle">Hosted on WP</label>
+            </div>
         </div>
 
         <article class="content px-4">
@@ -33,6 +37,8 @@
 
     private string? currentEndpoint;
     private string? currentUsername;
+    private const string HostInWpKey = "hostInWp";
+    private bool hostInWp = false;
     private DotNetObjectReference<MainLayout>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -43,6 +49,7 @@
         {
             username = await GetUsernameAsync(endpoint);
         }
+        var hostPref = await JS.InvokeAsync<string?>("localStorage.getItem", HostInWpKey);
 
         var changed = false;
         if (endpoint != currentEndpoint)
@@ -53,6 +60,12 @@
         if (username != currentUsername)
         {
             currentUsername = username;
+            changed = true;
+        }
+        var hostVal = !string.IsNullOrEmpty(hostPref) && bool.TryParse(hostPref, out var hv) ? hv : false;
+        if (hostVal != hostInWp)
+        {
+            hostInWp = hostVal;
             changed = true;
         }
 
@@ -100,6 +113,11 @@
         }
 
         return null;
+    }
+
+    private async Task OnHostInWpChanged()
+    {
+        await JS.InvokeVoidAsync("localStorage.setItem", HostInWpKey, hostInWp.ToString().ToLowerInvariant());
     }
 
     public async ValueTask DisposeAsync()


### PR DESCRIPTION
## Summary
- add a toggle for "Hosted on WP" in the main layout's top bar
- save and restore the preference from `localStorage`

## Testing
- `apt-get update` *(fails: Invalid response from proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6872316f6d5c8322917d81acf030f336