### PR TITLE
Add WordPress nonce display

### DIFF
--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -23,6 +23,10 @@
                 <input class="form-check-input" type="checkbox" id="hostInWpToggle" @bind="hostInWp" @bind:after="OnHostInWpChanged" />
                 <label class="form-check-label" for="hostInWpToggle">Hosted on WP</label>
             </div>
+            @if (hostInWp)
+            {
+                <span class="ms-2">Nonce: @nonceMessage</span>
+            }
         </div>
 
         <article class="content px-4">
@@ -39,6 +43,7 @@
     private string? currentUsername;
     private const string HostInWpKey = "hostInWp";
     private bool hostInWp = false;
+    private string? nonceMessage;
     private DotNetObjectReference<MainLayout>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
@@ -67,12 +72,24 @@
         {
             hostInWp = hostVal;
             changed = true;
+            if (hostInWp)
+            {
+                await FetchNonce();
+            }
+            else
+            {
+                nonceMessage = null;
+            }
         }
 
         if (firstRender)
         {
             _objRef = DotNetObjectReference.Create(this);
             await JS.InvokeVoidAsync("wpEndpointSync.register", _objRef);
+            if (hostInWp)
+            {
+                await FetchNonce();
+            }
         }
 
         if (changed)
@@ -118,6 +135,30 @@
     private async Task OnHostInWpChanged()
     {
         await JS.InvokeVoidAsync("localStorage.setItem", HostInWpKey, hostInWp.ToString().ToLowerInvariant());
+        if (hostInWp)
+        {
+            await FetchNonce();
+        }
+        else
+        {
+            nonceMessage = null;
+            await InvokeAsync(StateHasChanged);
+        }
+    }
+
+    private async Task FetchNonce()
+    {
+        nonceMessage = "Loading...";
+        try
+        {
+            var nonce = await JS.InvokeAsync<string?>("wpNonce.getNonce");
+            nonceMessage = !string.IsNullOrEmpty(nonce) ? nonce : "Could not retrieve nonce";
+        }
+        catch
+        {
+            nonceMessage = "Could not retrieve nonce";
+        }
+        await InvokeAsync(StateHasChanged);
     }
 
     public async ValueTask DisposeAsync()

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -41,6 +41,7 @@
     <script src="js/pdTreeToggle.js"></script>
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
+    <script src="js/wpNonce.js"></script>
     <script src="js/tinyMceConfig.js"></script>
 </body>
 

--- a/wwwroot/js/wpNonce.js
+++ b/wwwroot/js/wpNonce.js
@@ -1,0 +1,19 @@
+window.wpNonce = {
+  getNonce: async function () {
+    try {
+      const nonce = await fetch('/wp-admin/admin-ajax.php?action=rest-nonce', {
+        credentials: 'same-origin'
+      }).then(r => r.text());
+      if (!nonce) return null;
+      await fetch('/wp-json/wp/v2/users/me', {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { 'X-WP-Nonce': nonce }
+      }).then(r => r.json());
+      return nonce;
+    } catch (err) {
+      console.log('Failed to retrieve nonce', err);
+      return null;
+    }
+  }
+};


### PR DESCRIPTION
## Summary
- show a nonce next to the "Hosted on WP" toggle
- fetch nonce via new `wpNonce.js` script

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045)*

------
https://chatgpt.com/codex/tasks/task_e_68723998922c832299c4dcab830815d0