### PR TITLE
Implement unified WordPress auth handler

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,10 +17,10 @@ namespace BlazorWP
             builder.RootComponents.Add<HeadOutlet>("head::after");
 
             // 3) Your services
-            builder.Services.AddScoped<JwtAuthMessageHandler>();
+            builder.Services.AddScoped<AuthMessageHandler>();
             builder.Services.AddScoped(sp =>
             {
-                var handler = sp.GetRequiredService<JwtAuthMessageHandler>();
+                var handler = sp.GetRequiredService<AuthMessageHandler>();
                 return new HttpClient(handler) { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) };
             });
             builder.Services.AddMudServices();


### PR DESCRIPTION
## Summary
- rename JwtAuthMessageHandler to AuthMessageHandler
- allow using WP nonce when "Hosted on WP" is enabled
- register AuthMessageHandler in Program.cs

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_68732ff1abf48322b67f0809f51dfba2