### PR TITLE
Fix auth on WordPress editor

### DIFF
--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Linq;
 using System.Collections.Generic;
+using System.Net.Http;
 using Microsoft.JSInterop;
 using WordPressPCL;
 using WordPressPCL.Models;
@@ -119,12 +120,8 @@ public partial class Edit
 
         baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
         //Console.WriteLine($"[SetupWordPressClientAsync] baseUrl={baseUrl}");
-        client = new WordPressClient(baseUrl);
-        var token = await JwtService.GetCurrentJwtAsync();
-        if (!string.IsNullOrEmpty(token))
-        {
-            client.Auth.SetJWToken(token);
-            //Console.WriteLine("[SetupWordPressClientAsync] token configured");
-        }
+        var handler = AuthHandler;
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseUrl) };
+        client = new WordPressClient(httpClient);
     }
 }

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -6,6 +6,7 @@
 @inject HttpClient Http
 @inject IJSRuntime JS
 @inject JwtService JwtService
+@inject AuthMessageHandler AuthHandler
 @implements IAsyncDisposable
 
 <PageTitle>Edit</PageTitle>


### PR DESCRIPTION
## Summary
- inject `AuthMessageHandler` in `Edit` page
- create `WordPressClient` with `AuthMessageHandler`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68734c74416883229c6ef8ee893adad7