### PR TITLE
Add navbar link to PDF demo

### DIFF
--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -69,6 +69,11 @@
                 <span class="bi bi-plug-fill-nav-menu" aria-hidden="true"></span> PCL Demo
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <a class="nav-link" href="pdf2img-jsdelivr.html">
+                <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> PDF Demo
+            </a>
+        </div>
     </nav>
 </div>
 


### PR DESCRIPTION
## Summary
- add PDF demo link in NavMenu

## Testing
- `dotnet restore`
- `dotnet build --no-restore`

------
https://chatgpt.com/codex/tasks/task_e_687461228ff88322a23be9533ec57e1d