### PR TITLE
Add WordPress media popup demo page

### DIFF
--- a/Data/MediaInterop.cs
+++ b/Data/MediaInterop.cs
@@ -1,0 +1,14 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public static class MediaInterop
+{
+    public static event Action<string>? MediaSelected;
+
+    [JSInvokable]
+    public static void OnMediaSelected(string json)
+    {
+        MediaSelected?.Invoke(json);
+    }
+}

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -70,6 +70,11 @@
             </NavLink>
         </div>
         <div class="nav-item px-3">
+            <NavLink class="nav-link" href="wp-media-demo">
+                <span class="bi bi-images" aria-hidden="true"></span> Media Popup
+            </NavLink>
+        </div>
+        <div class="nav-item px-3">
             <NavLink class="nav-link" href="pdf-demo">
                 <span class="bi bi-list-nested-nav-menu" aria-hidden="true"></span> PDF Demo
             </NavLink>

--- a/Pages/WpMediaDemo.razor
+++ b/Pages/WpMediaDemo.razor
@@ -1,0 +1,40 @@
+@page "/wp-media-demo"
+@inject IJSRuntime JS
+@implements IDisposable
+
+<PageTitle>WP Media Demo</PageTitle>
+
+<h1>WordPress Media Popup</h1>
+
+<button class="btn btn-primary mb-3" @onclick="OpenMedia">Open Media Library</button>
+
+@if (!string.IsNullOrEmpty(selectedAttachment))
+{
+    <p>Selected attachment:</p>
+    <pre class="json-view">@selectedAttachment</pre>
+}
+
+@code {
+    private string? selectedAttachment;
+
+    protected override void OnInitialized()
+    {
+        MediaInterop.MediaSelected += HandleMediaSelected;
+    }
+
+    private async Task OpenMedia()
+    {
+        await JS.InvokeVoidAsync("launchWpMedia");
+    }
+
+    private void HandleMediaSelected(string json)
+    {
+        selectedAttachment = json;
+        InvokeAsync(StateHasChanged);
+    }
+
+    public void Dispose()
+    {
+        MediaInterop.MediaSelected -= HandleMediaSelected;
+    }
+}

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -16,6 +16,31 @@
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
+
+    <!-- WordPress media scripts -->
+    <script src="https://yasuaki.com/wp-admin/load-scripts.php?load=jquery-core,underscore,backbone,media-models,media-views,media-editor"></script>
+    <script>
+        window.wpApiSettings = { root: '/wp-json/', nonce: '' };
+        window.launchWpMedia = async () => {
+            if (window.wpNonce && !window.wpApiSettings.nonce) {
+                const n = await window.wpNonce.getNonce();
+                if (n) {
+                    window.wpApiSettings.nonce = n;
+                }
+            }
+            const frame = wp.media({
+                title: 'Select or Upload Media',
+                library: { type: 'image' },
+                button: { text: 'Insert Image' },
+                multiple: false
+            });
+            frame.on('select', () => {
+                const attachment = frame.state().get('selection').first().toJSON();
+                DotNet.invokeMethodAsync('BlazorWP', 'OnMediaSelected', JSON.stringify(attachment));
+            });
+            frame.open();
+        };
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary
- add WP media JS setup to `index.html`
- expose `MediaInterop` static class for JS callbacks
- add `WpMediaDemo` Razor page demonstrating the popup
- link the new page in the sidebar

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6874b7efd69c8322afde6a8cffcf1eaf