### PR TITLE
Add preview step for PDF upload

### DIFF
--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -14,14 +14,52 @@
 else
 {
     <div class="mb-3">
-        <input type="file" class="form-control" accept="application/pdf" @onchange="HandleFileChange" />
+        <input id="file-input" type="file" class="form-control" accept="application/pdf" @onchange="HandleFileChange" />
     </div>
+    <canvas id="canvas" style="display:none;"></canvas>
+    <img id="preview" class="img-fluid mb-3" alt="PDF preview" />
     <button class="btn btn-primary" @onclick="UploadAsync" disabled="@(_file == null)">Upload to WordPress</button>
     @if (!string.IsNullOrEmpty(status))
     {
         <div class="mt-2">@status</div>
     }
 }
+
+<script type="module">
+    import * as pdfjsLib from './libman/pdfjs-dist/build/pdf.mjs';
+    pdfjsLib.GlobalWorkerOptions.workerSrc = './libman/pdfjs-dist/build/pdf.worker.mjs';
+
+    const cMapBaseUrl = './libman/pdfjs-dist/cmaps/';
+    const cMapPacked  = true;
+
+    const { getDocument } = pdfjsLib;
+    const fileInput = document.getElementById('file-input');
+    const canvas    = document.getElementById('canvas');
+    const outputImg = document.getElementById('preview');
+
+    fileInput?.addEventListener('change', async () => {
+        const file = fileInput.files[0];
+        if (!file) return;
+
+        const arrayBuffer = await file.arrayBuffer();
+        const loadingTask = getDocument({
+            data: arrayBuffer,
+            cMapUrl:  cMapBaseUrl,
+            cMapPacked
+        });
+        const pdf = await loadingTask.promise;
+
+        const page     = await pdf.getPage(1);
+        const viewport = page.getViewport({ scale: 2 });
+
+        canvas.width  = viewport.width;
+        canvas.height = viewport.height;
+        const ctx = canvas.getContext('2d');
+        await page.render({ canvasContext: ctx, viewport }).promise;
+
+        outputImg.src = canvas.toDataURL('image/png');
+    });
+</script>
 
 @code {
     private WordPressClient? client;


### PR DESCRIPTION
## Summary
- preview PDFs client-side before upload using pdfjs-dist

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687611cf62688322abacf6dbcddf83c2