### PR TITLE
Add progress bar on PDF upload

### DIFF
--- a/Data/ProgressStream.cs
+++ b/Data/ProgressStream.cs
@@ -1,0 +1,53 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BlazorWP;
+
+public class ProgressStream : Stream
+{
+    private readonly Stream _inner;
+    private readonly Action<long, long> _progress;
+    private long _bytesRead;
+
+    public ProgressStream(Stream inner, Action<long, long> progress)
+    {
+        _inner = inner;
+        _progress = progress;
+    }
+
+    private void Report(int read)
+    {
+        if (read <= 0)
+        {
+            return;
+        }
+        _bytesRead += read;
+        _progress?.Invoke(_bytesRead, Length);
+    }
+
+    public override bool CanRead => _inner.CanRead;
+    public override bool CanSeek => _inner.CanSeek;
+    public override bool CanWrite => _inner.CanWrite;
+    public override long Length => _inner.Length;
+    public override long Position { get => _inner.Position; set => _inner.Position = value; }
+    public override void Flush() => _inner.Flush();
+    public override long Seek(long offset, SeekOrigin origin) => _inner.Seek(offset, origin);
+    public override void SetLength(long value) => _inner.SetLength(value);
+    public override void Write(byte[] buffer, int offset, int count) => _inner.Write(buffer, offset, count);
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        int read = _inner.Read(buffer, offset, count);
+        Report(read);
+        return read;
+    }
+
+    public override async ValueTask<int> ReadAsync(Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        int read = await _inner.ReadAsync(buffer, cancellationToken);
+        Report(read);
+        return read;
+    }
+}

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -16,18 +16,24 @@ else
 {
     <div class="mb-3">
         <InputFile id="file-input" class="form-control" accept="application/pdf" OnChange="HandleFileChange" />
-
-
     </div>
-    <button id="upload-btn" class="btn btn-primary mb-3" @onclick="UploadAsync" disabled="@(_file == null)">Upload to WordPress</button>
+    <div class="d-flex align-items-center gap-2 mb-3">
+        <button id="upload-btn" class="btn btn-primary" @onclick="UploadAsync" disabled="@(_file == null)">Upload to WordPress</button>
+        @if (!string.IsNullOrEmpty(status))
+        {
+            <span>@status</span>
+        }
+    </div>
+    @if (isUploading)
+    {
+        <div class="progress mb-3">
+            <div class="progress-bar" role="progressbar" style="width: @uploadProgress%" aria-valuenow="@uploadProgress" aria-valuemin="0" aria-valuemax="100">@uploadProgress%</div>
+        </div>
+    }
     <canvas id="canvas" style="display:none;"></canvas>
     <div class="preview-wrapper">
         <img id="preview" class="preview-image mb-3" alt="PDF preview" />
     </div>
-    @if (!string.IsNullOrEmpty(status))
-    {
-        <div class="mt-2">@status</div>
-    }
 }
 
 <script type="module">
@@ -84,6 +90,8 @@ else
     private WordPressClient? client;
     private IBrowserFile? _file;
     private string? status;
+    private int uploadProgress;
+    private bool isUploading;
 
     protected override async Task OnInitializedAsync()
     {
@@ -109,16 +117,28 @@ else
             return;
         }
 
-        status = "Uploading...";
+        status = null;
+        uploadProgress = 0;
+        isUploading = true;
         try
         {
             using var stream = _file.OpenReadStream(long.MaxValue);
-            var media = await client.Media.CreateAsync(stream, _file.Name, "application/pdf");
+            using var progressStream = new ProgressStream(stream, (sent, total) =>
+            {
+                uploadProgress = (int)(sent * 100 / total);
+                InvokeAsync(StateHasChanged);
+            });
+            var media = await client.Media.CreateAsync(progressStream, _file.Name, "application/pdf");
             status = $"Uploaded media ID: {media.Id}";
+            uploadProgress = 100;
         }
         catch (Exception ex)
         {
             status = $"Error: {ex.Message}";
+        }
+        finally
+        {
+            isUploading = false;
         }
     }
 }


### PR DESCRIPTION
## Summary
- show upload status next to the button
- add bootstrap progress bar during upload
- report progress with new `ProgressStream` wrapper

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_68761c3ba2fc83229a2ce6b81cec8191