### PR TITLE
Fix PDF upload to assign preview thumbnail

### DIFF
--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using System.IO
 @using System.Text.RegularExpressions
+@using System.Collections.Generic
 @inject IJSRuntime JS
 @inject AuthMessageHandler AuthHandler
 
@@ -144,7 +145,13 @@ else
                 var bytes = Convert.FromBase64String(base64);
                 using var imageStream = new MemoryStream(bytes);
                 var thumb = await client.Media.CreateAsync(imageStream, Path.ChangeExtension(_file.Name, ".png"), "image/png");
-                media.Meta = new { _thumbnail_id = thumb.Id };
+                thumb.Post = media.Id;
+                await client.Media.UpdateAsync(thumb);
+
+                media.Meta = new Dictionary<string, object>
+                {
+                    ["_thumbnail_id"] = thumb.Id
+                };
                 await client.Media.UpdateAsync(media);
                 status = $"Uploaded media ID: {media.Id} (thumbnail {thumb.Id})";
             }


### PR DESCRIPTION
## Summary
- link generated preview image to the uploaded PDF
- update PDF metadata with `_thumbnail_id`

## Testing
- `apt-get install -y mono-utils`
- `apt-get install -y mono-devel`
- `apt-get install -y mono-complete`
- `apt-get install -y libnewtonsoft-json-cil-dev`

------
https://chatgpt.com/codex/tasks/task_e_687623b721088322add1de54da181100