### PR TITLE
Integrate upload-pdf.js via DI service

### DIFF
--- a/Data/UploadPdfJsInterop.cs
+++ b/Data/UploadPdfJsInterop.cs
@@ -1,0 +1,43 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class UploadPdfJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public UploadPdfJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/upload-pdf.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask InitializeAsync(string canvasId, string imgId)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("initialize", canvasId, imgId);
+    }
+
+    public async ValueTask RenderFirstPageAsync(DotNetStreamReference streamRef, string canvasId, string imgId)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("renderFirstPageFromStream", streamRef, canvasId, imgId);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -3,6 +3,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
 @inject IJSRuntime JS
+@inject UploadPdfJsInterop PdfJs
 @inject AuthMessageHandler AuthHandler
 
 <PageTitle>Upload PDF</PageTitle>
@@ -39,7 +40,6 @@ else
     private string? status;
     private int uploadProgress;
     private bool isUploading;
-    private IJSObjectReference? _pdfModule;
     private DotNetStreamReference? _fileStreamRef;
 
     protected override async Task OnInitializedAsync()
@@ -55,25 +55,20 @@ else
     {
         if (firstRender)
         {
-            _pdfModule = await JS.InvokeAsync<IJSObjectReference>("import", "./js/upload-pdf.js");
-            if (_pdfModule != null)
-                await _pdfModule.InvokeVoidAsync("initialize", "canvas", "preview");
+            await PdfJs.InitializeAsync("canvas", "preview");
         }
     }
 
     private async Task OnFileSelected(InputFileChangeEventArgs e)
     {
         _file = e.File;
-        if (_pdfModule != null && _file != null)
+        if (_file != null)
         {
-            // Wrap the .NET file stream in a JS-readable stream reference
             _fileStreamRef = new(_file.OpenReadStream(long.MaxValue));
-            await _pdfModule.InvokeVoidAsync(
-                "renderFirstPageFromStream",
+            await PdfJs.RenderFirstPageAsync(
                 _fileStreamRef,
                 "canvas",
-                "preview"
-            );
+                "preview");
         }
     }
 
@@ -102,6 +97,6 @@ else
 
     public async ValueTask DisposeAsync()
     {
-        if (_pdfModule != null) await _pdfModule.DisposeAsync();
+        await PdfJs.DisposeAsync();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -27,6 +27,7 @@ namespace BlazorWP
             builder.Services.AddPanoramicDataBlazor();
             builder.Services.AddAntDesign();
             builder.Services.AddScoped<JwtService>();
+            builder.Services.AddScoped<UploadPdfJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- create `UploadPdfJsInterop` DI service to manage module load and disposal
- register new service in Program.cs
- refactor UploadPdf page to use the service

## Testing
- `dotnet build -c Release` *(fails: .NET 9 SDK unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68785413d858832290d3537359933591