### PR TITLE
Convert local scripts to JS modules

### DIFF
--- a/Data/AuthMessageHandler.cs
+++ b/Data/AuthMessageHandler.cs
@@ -7,12 +7,14 @@ public class AuthMessageHandler : DelegatingHandler
 {
     private readonly JwtService _jwtService;
     private readonly IJSRuntime _js;
+    private readonly WpNonceJsInterop _nonceJs;
     private const string HostInWpKey = "hostInWp";
 
-    public AuthMessageHandler(JwtService jwtService, IJSRuntime js)
+    public AuthMessageHandler(JwtService jwtService, IJSRuntime js, WpNonceJsInterop nonceJs)
     {
         _jwtService = jwtService;
         _js = js;
+        _nonceJs = nonceJs;
         InnerHandler = new HttpClientHandler();
     }
 
@@ -36,7 +38,7 @@ public class AuthMessageHandler : DelegatingHandler
 
         if (useNonce)
         {
-            var nonce = await _js.InvokeAsync<string?>("wpNonce.getNonce");
+            var nonce = await _nonceJs.GetNonceAsync();
             if (!string.IsNullOrWhiteSpace(nonce))
             {
                 if (!ShouldSkipAuth(request))

--- a/Data/StorageJsInterop.cs
+++ b/Data/StorageJsInterop.cs
@@ -1,0 +1,55 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class StorageJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public StorageJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/storageUtils.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask<string[]> KeysAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string[]>("keys");
+    }
+
+    public async ValueTask<ItemInfo> ItemInfoAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<ItemInfo>("itemInfo", key);
+    }
+
+    public async ValueTask DeleteAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("deleteItem", key);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+
+    public class ItemInfo
+    {
+        public string? Value { get; set; }
+        public string? LastUpdated { get; set; }
+    }
+}

--- a/Data/WpEndpointSyncJsInterop.cs
+++ b/Data/WpEndpointSyncJsInterop.cs
@@ -1,0 +1,49 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpEndpointSyncJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public WpEndpointSyncJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/wpEndpointSync.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask RegisterAsync<T>(DotNetObjectReference<T> objRef) where T : class
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("register", objRef);
+    }
+
+    public async ValueTask UnregisterAsync()
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("unregister");
+    }
+
+    public async ValueTask SetAsync(string value)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("set", value);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Data/WpMediaJsInterop.cs
+++ b/Data/WpMediaJsInterop.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpMediaJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public WpMediaJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/wpMedia.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask InitMediaPageAsync(ElementReference iframeEl, ElementReference overlayEl)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("initMediaPage", iframeEl, overlayEl);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Data/WpNonceJsInterop.cs
+++ b/Data/WpNonceJsInterop.cs
@@ -1,0 +1,37 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpNonceJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public WpNonceJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/wpNonce.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask<string?> GetNonceAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string?>("getNonce");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -38,6 +38,10 @@
 @code {
     [Inject]
     private IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    private WpEndpointSyncJsInterop EndpointSync { get; set; } = default!;
+    [Inject]
+    private WpNonceJsInterop NonceJs { get; set; } = default!;
 
     private string? currentEndpoint;
     private string? currentUsername;
@@ -85,7 +89,7 @@
         if (firstRender)
         {
             _objRef = DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("wpEndpointSync.register", _objRef);
+            await EndpointSync.RegisterAsync(_objRef);
             if (hostInWp)
             {
                 await FetchNonce();
@@ -151,7 +155,7 @@
         nonceMessage = "Loading...";
         try
         {
-            var nonce = await JS.InvokeAsync<string?>("wpNonce.getNonce");
+            var nonce = await NonceJs.GetNonceAsync();
             nonceMessage = !string.IsNullOrEmpty(nonce) ? nonce : "Could not retrieve nonce";
         }
         catch
@@ -165,7 +169,7 @@
     {
         if (_objRef != null)
         {
-            await JS.InvokeVoidAsync("wpEndpointSync.unregister");
+            await EndpointSync.UnregisterAsync();
             _objRef.Dispose();
         }
     }

--- a/Pages/DataStorage.razor
+++ b/Pages/DataStorage.razor
@@ -1,5 +1,5 @@
 @page "/data-storage"
-@inject IJSRuntime JS
+@inject StorageJsInterop StorageJs
 
 <PageTitle>Data Storage</PageTitle>
 
@@ -50,10 +50,10 @@ else
     protected override async Task OnInitializedAsync()
     {
         items = new();
-        var keys = await JS.InvokeAsync<string[]>("blazorwpStorage.keys");
+        var keys = await StorageJs.KeysAsync();
         foreach (var key in keys)
         {
-            var info = await JS.InvokeAsync<ItemInfo>("blazorwpStorage.itemInfo", key);
+            var info = await StorageJs.ItemInfoAsync(key);
             items.Add(new StoredItem
             {
                 Key = key,
@@ -68,13 +68,8 @@ else
         {
             items.RemoveAll(i => i.Key == key);
         }
-        await JS.InvokeVoidAsync("blazorwpStorage.delete", key);
+        await StorageJs.DeleteAsync(key);
         await InvokeAsync(StateHasChanged);
-    }
-
-    private class ItemInfo
-    {
-        public string? Value { get; set; }
     }
 
     private class StoredItem

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -182,6 +182,8 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
 
     [Inject]
     private IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    private WpEndpointSyncJsInterop EndpointSync { get; set; } = default!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -332,7 +334,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                     var root = baseUri.ToString().TrimEnd('/');
                     verifiedEndpoint = root;
                     userUrl = root;
-                    await JS.InvokeVoidAsync("wpEndpointSync.set", root);
+                    await EndpointSync.SetAsync(root);
 
                     var siteInfo = await LoadSiteInfoAsync();
                     if (!siteInfo.ContainsKey(root))

--- a/Pages/Media.razor
+++ b/Pages/Media.razor
@@ -1,5 +1,5 @@
 @page "/media"
-@inject IJSRuntime JS
+@inject WpMediaJsInterop MediaJs
 
     <h3 id="media-library-label" class="px-4 mb-2">Media Library</h3>
 
@@ -19,7 +19,7 @@
   {
     if (firstRender)
     {
-      await JS.InvokeVoidAsync("wpMedia.initMediaPage", iframeEl, overlayEl);
+      await MediaJs.InitMediaPageAsync(iframeEl, overlayEl);
     }
   }
 

--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,10 @@ namespace BlazorWP
             builder.Services.AddAntDesign();
             builder.Services.AddScoped<JwtService>();
             builder.Services.AddScoped<UploadPdfJsInterop>();
+            builder.Services.AddScoped<StorageJsInterop>();
+            builder.Services.AddScoped<WpEndpointSyncJsInterop>();
+            builder.Services.AddScoped<WpNonceJsInterop>();
+            builder.Services.AddScoped<WpMediaJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -33,11 +33,7 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="js/storageUtils.js"></script>
-    <script src="js/wpEndpointSync.js"></script>
-    <script src="js/wpNonce.js"></script>
     <script src="js/tinyMceConfig.js"></script>
-    <script src="js/wpMedia.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/storageUtils.js
+++ b/wwwroot/js/storageUtils.js
@@ -1,20 +1,24 @@
-window.blazorwpStorage = {
-  keys: () => Object.keys(window.localStorage),
-  itemInfo: key => {
-    const value = window.localStorage.getItem(key);
-    let ts = window.localStorage.getItem(key + '_timestamp');
-    if (!ts && value) {
-      try {
-        const obj = JSON.parse(value);
-        if (obj && typeof obj === 'object' && obj.lastUpdated) {
-          ts = obj.lastUpdated;
-        }
-      } catch { }
+export function keys() {
+  return Object.keys(window.localStorage);
+}
+
+export function itemInfo(key) {
+  const value = window.localStorage.getItem(key);
+  let ts = window.localStorage.getItem(key + '_timestamp');
+  if (!ts && value) {
+    try {
+      const obj = JSON.parse(value);
+      if (obj && typeof obj === 'object' && obj.lastUpdated) {
+        ts = obj.lastUpdated;
+      }
+    } catch {
+      // ignore JSON errors
     }
-    return { value: value, lastUpdated: ts };
-  },
-  delete: key => {
-    window.localStorage.removeItem(key);
-    window.localStorage.removeItem(key + '_timestamp');
   }
-};
+  return { value: value, lastUpdated: ts };
+}
+
+export function deleteItem(key) {
+  window.localStorage.removeItem(key);
+  window.localStorage.removeItem(key + '_timestamp');
+}

--- a/wwwroot/js/wpEndpointSync.js
+++ b/wwwroot/js/wpEndpointSync.js
@@ -1,25 +1,25 @@
-window.wpEndpointSync = (function () {
-  let dotNetHelper = null;
-  function handleStorage(e) {
-    if (e.key === 'wpEndpoint' && dotNetHelper) {
-      dotNetHelper.invokeMethodAsync('UpdateEndpoint', e.newValue);
-    }
+let dotNetHelper = null;
+
+function handleStorage(e) {
+  if (e.key === 'wpEndpoint' && dotNetHelper) {
+    dotNetHelper.invokeMethodAsync('UpdateEndpoint', e.newValue);
   }
-  return {
-    register: function (dotnet) {
-      dotNetHelper = dotnet;
-      window.addEventListener('storage', handleStorage);
-      dotnet.invokeMethodAsync('UpdateEndpoint', localStorage.getItem('wpEndpoint'));
-    },
-    unregister: function () {
-      window.removeEventListener('storage', handleStorage);
-      dotNetHelper = null;
-    },
-    set: function (value) {
-      localStorage.setItem('wpEndpoint', value);
-      if (dotNetHelper) {
-        dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
-      }
-    }
-  };
-})();
+}
+
+export function register(dotnet) {
+  dotNetHelper = dotnet;
+  window.addEventListener('storage', handleStorage);
+  dotnet.invokeMethodAsync('UpdateEndpoint', localStorage.getItem('wpEndpoint'));
+}
+
+export function unregister() {
+  window.removeEventListener('storage', handleStorage);
+  dotNetHelper = null;
+}
+
+export function set(value) {
+  localStorage.setItem('wpEndpoint', value);
+  if (dotNetHelper) {
+    dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
+  }
+}

--- a/wwwroot/js/wpMedia.js
+++ b/wwwroot/js/wpMedia.js
@@ -1,5 +1,4 @@
-window.wpMedia = {
-  initMediaPage: function(iframeEl, overlayEl) {
+export function initMediaPage(iframeEl, overlayEl) {
     console.log("↪ wpMedia.initMediaPage called");
 
     // 1) hide the overlay once the iframe really loads
@@ -65,5 +64,4 @@ window.wpMedia = {
     window.addEventListener("resize", adjustMedia);
     // initial sizing
     adjustMedia();
-  }
-};
+}

--- a/wwwroot/js/wpNonce.js
+++ b/wwwroot/js/wpNonce.js
@@ -1,19 +1,18 @@
-window.wpNonce = {
-  getNonce: async function () {
-    try {
-      const nonce = await fetch('/wp-admin/admin-ajax.php?action=rest-nonce', {
-        credentials: 'same-origin'
-      }).then(r => r.text());
-      if (!nonce) return null;
-      await fetch('/wp-json/wp/v2/users/me', {
-        method: 'GET',
-        credentials: 'same-origin',
-        headers: { 'X-WP-Nonce': nonce }
-      }).then(r => r.json());
-      return nonce;
-    } catch (err) {
-      console.log('Failed to retrieve nonce', err);
-      return null;
-    }
+
+export async function getNonce() {
+  try {
+    const nonce = await fetch('/wp-admin/admin-ajax.php?action=rest-nonce', {
+      credentials: 'same-origin'
+    }).then(r => r.text());
+    if (!nonce) return null;
+    await fetch('/wp-json/wp/v2/users/me', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { 'X-WP-Nonce': nonce }
+    }).then(r => r.json());
+    return nonce;
+  } catch (err) {
+    console.log('Failed to retrieve nonce', err);
+    return null;
   }
-};
+}


### PR DESCRIPTION
## Summary
- wrap `storageUtils.js`, `wpEndpointSync.js`, `wpNonce.js` and `wpMedia.js` as ES modules
- add JS interop service classes for accessing those modules
- inject new services in pages and layout
- register services in `Program.cs`
- remove script tags for the converted scripts

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68786be1bea88322ae78ffdedccfb927