### PR TITLE
Use endpoint sync service in JwtService

### DIFF
--- a/Data/JwtService.cs
+++ b/Data/JwtService.cs
@@ -7,12 +7,13 @@ namespace BlazorWP;
 public class JwtService
 {
     private readonly IJSRuntime _js;
-    private const string WpEndpointKey = "wpEndpoint";
+    private readonly WpEndpointSyncJsInterop _endpointSync;
     private const string SiteInfoKey = "siteinfo";
 
-    public JwtService(IJSRuntime js)
+    public JwtService(IJSRuntime js, WpEndpointSyncJsInterop endpointSync)
     {
         _js = js;
+        _endpointSync = endpointSync;
     }
 
     private class JwtInfo
@@ -104,7 +105,7 @@ public class JwtService
 
     public async Task<string?> GetCurrentJwtAsync()
     {
-        var endpoint = await _js.InvokeAsync<string?>("localStorage.getItem", WpEndpointKey);
+        var endpoint = await _endpointSync.GetAsync();
         if (string.IsNullOrEmpty(endpoint))
         {
             return null;

--- a/Data/WpEndpointSyncJsInterop.cs
+++ b/Data/WpEndpointSyncJsInterop.cs
@@ -39,6 +39,12 @@ public class WpEndpointSyncJsInterop : IAsyncDisposable
         await module.InvokeVoidAsync("set", value);
     }
 
+    public async ValueTask<string?> GetAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string?>("get");
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_module != null)

--- a/wwwroot/js/wpEndpointSync.js
+++ b/wwwroot/js/wpEndpointSync.js
@@ -23,3 +23,7 @@ export function set(value) {
     dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
   }
 }
+
+export function get() {
+  return localStorage.getItem('wpEndpoint');
+}


### PR DESCRIPTION
## Summary
- add `GetAsync` to `WpEndpointSyncJsInterop` and JS module
- switch `JwtService` to use the endpoint sync interop

## Testing
- `dotnet build BlazorWP.sln -v:m`
- `dotnet test BlazorWP.sln`

------
https://chatgpt.com/codex/tasks/task_e_687880ecbda48322a1e3aeccfb3dfbad