### PR TITLE
Add HostInWp JS interop service

### DIFF
--- a/Data/AuthMessageHandler.cs
+++ b/Data/AuthMessageHandler.cs
@@ -6,14 +6,13 @@ namespace BlazorWP;
 public class AuthMessageHandler : DelegatingHandler
 {
     private readonly JwtService _jwtService;
-    private readonly IJSRuntime _js;
+    private readonly HostInWpJsInterop _hostJs;
     private readonly WpNonceJsInterop _nonceJs;
-    private const string HostInWpKey = "hostInWp";
 
-    public AuthMessageHandler(JwtService jwtService, IJSRuntime js, WpNonceJsInterop nonceJs)
+    public AuthMessageHandler(JwtService jwtService, HostInWpJsInterop hostJs, WpNonceJsInterop nonceJs)
     {
         _jwtService = jwtService;
-        _js = js;
+        _hostJs = hostJs;
         _nonceJs = nonceJs;
         InnerHandler = new HttpClientHandler();
     }
@@ -33,8 +32,8 @@ public class AuthMessageHandler : DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hostPref = await _js.InvokeAsync<string?>("localStorage.getItem", HostInWpKey);
-        var useNonce = !string.IsNullOrEmpty(hostPref) && bool.TryParse(hostPref, out var hv) && hv;
+        var hostPref = await _hostJs.GetAsync();
+        var useNonce = hostPref == true;
 
         if (useNonce)
         {

--- a/Data/HostInWpJsInterop.cs
+++ b/Data/HostInWpJsInterop.cs
@@ -1,0 +1,43 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class HostInWpJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public HostInWpJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/hostInWp.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask<bool?> GetAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<bool?>("get");
+    }
+
+    public async ValueTask SetAsync(bool value)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("set", value);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -42,23 +42,24 @@
     private WpEndpointSyncJsInterop EndpointSync { get; set; } = default!;
     [Inject]
     private WpNonceJsInterop NonceJs { get; set; } = default!;
+    [Inject]
+    private HostInWpJsInterop HostJs { get; set; } = default!;
 
     private string? currentEndpoint;
     private string? currentUsername;
-    private const string HostInWpKey = "hostInWp";
     private bool hostInWp = true;
     private string? nonceMessage;
     private DotNetObjectReference<MainLayout>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await EndpointSync.GetAsync();
         string? username = null;
         if (!string.IsNullOrEmpty(endpoint))
         {
             username = await GetUsernameAsync(endpoint);
         }
-        var hostPref = await JS.InvokeAsync<string?>("localStorage.getItem", HostInWpKey);
+        var hostPref = await HostJs.GetAsync();
 
         var changed = false;
         if (endpoint != currentEndpoint)
@@ -71,7 +72,7 @@
             currentUsername = username;
             changed = true;
         }
-        var hostVal = !string.IsNullOrEmpty(hostPref) && bool.TryParse(hostPref, out var hv) ? hv : true;
+        var hostVal = hostPref ?? true;
         if (hostVal != hostInWp)
         {
             hostInWp = hostVal;
@@ -138,7 +139,7 @@
 
     private async Task OnHostInWpChanged()
     {
-        await JS.InvokeVoidAsync("localStorage.setItem", HostInWpKey, hostInWp.ToString().ToLowerInvariant());
+        await HostJs.SetAsync(hostInWp);
         if (hostInWp)
         {
             await FetchNonce();

--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,7 @@ namespace BlazorWP
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<WpNonceJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
+            builder.Services.AddScoped<HostInWpJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/js/hostInWp.js
+++ b/wwwroot/js/hostInWp.js
@@ -1,0 +1,10 @@
+export function get() {
+  const val = localStorage.getItem('hostInWp');
+  if (val === 'true') return true;
+  if (val === 'false') return false;
+  return null;
+}
+
+export function set(value) {
+  localStorage.setItem('hostInWp', value.toString());
+}


### PR DESCRIPTION
## Summary
- add `HostInWpJsInterop` service with `get` and `set` methods
- create `hostInWp.js` module to handle localStorage reads/writes
- register `HostInWpJsInterop` in DI container
- update `AuthMessageHandler` and `MainLayout` to use the new service
- use `WpEndpointSyncJsInterop.GetAsync()` in `MainLayout`

## Testing
- `dotnet build` *(fails: `dotnet` not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68788713850c832281b083e3af4aff12