### PR TITLE
Move wpNonce call to DI service

### DIFF
--- a/Data/AuthMessageHandler.cs
+++ b/Data/AuthMessageHandler.cs
@@ -7,12 +7,14 @@ public class AuthMessageHandler : DelegatingHandler
 {
     private readonly JwtService _jwtService;
     private readonly IJSRuntime _js;
+    private readonly WpNonceJsInterop _nonceJs;
     private const string HostInWpKey = "hostInWp";
 
-    public AuthMessageHandler(JwtService jwtService, IJSRuntime js)
+    public AuthMessageHandler(JwtService jwtService, IJSRuntime js, WpNonceJsInterop nonceJs)
     {
         _jwtService = jwtService;
         _js = js;
+        _nonceJs = nonceJs;
         InnerHandler = new HttpClientHandler();
     }
 
@@ -36,7 +38,7 @@ public class AuthMessageHandler : DelegatingHandler
 
         if (useNonce)
         {
-            var nonce = await _js.InvokeAsync<string?>("wpNonce.getNonce");
+            var nonce = await _nonceJs.GetNonceAsync();
             if (!string.IsNullOrWhiteSpace(nonce))
             {
                 if (!ShouldSkipAuth(request))

--- a/Data/WpNonceJsInterop.cs
+++ b/Data/WpNonceJsInterop.cs
@@ -1,0 +1,18 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpNonceJsInterop
+{
+    private readonly IJSRuntime _jsRuntime;
+
+    public WpNonceJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    public ValueTask<string?> GetNonceAsync()
+    {
+        return _jsRuntime.InvokeAsync<string?>("wpNonce.getNonce");
+    }
+}

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -38,6 +38,8 @@
 @code {
     [Inject]
     private IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    private WpNonceJsInterop NonceJs { get; set; } = default!;
 
     private string? currentEndpoint;
     private string? currentUsername;
@@ -151,7 +153,7 @@
         nonceMessage = "Loading...";
         try
         {
-            var nonce = await JS.InvokeAsync<string?>("wpNonce.getNonce");
+            var nonce = await NonceJs.GetNonceAsync();
             nonceMessage = !string.IsNullOrEmpty(nonce) ? nonce : "Could not retrieve nonce";
         }
         catch

--- a/Program.cs
+++ b/Program.cs
@@ -28,6 +28,7 @@ namespace BlazorWP
             builder.Services.AddAntDesign();
             builder.Services.AddScoped<JwtService>();
             builder.Services.AddScoped<UploadPdfJsInterop>();
+            builder.Services.AddScoped<WpNonceJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- create `WpNonceJsInterop` service for requesting WordPress nonces
- register the service in `Program.cs`
- inject and use the service in `MainLayout`
- update `AuthMessageHandler` to use the new service

## Testing
- `dotnet build -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878890eb0688322b1f8ca64272d4ce2