### PR TITLE
Convert wpNonce script to ESM

### DIFF
--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -35,7 +35,6 @@
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="js/storageUtils.js"></script>
     <script src="js/wpEndpointSync.js"></script>
-    <script src="js/wpNonce.js"></script>
     <script src="js/tinyMceConfig.js"></script>
     <script src="js/wpMedia.js"></script>
 </body>

--- a/wwwroot/js/wpNonce.js
+++ b/wwwroot/js/wpNonce.js
@@ -1,19 +1,17 @@
-window.wpNonce = {
-  getNonce: async function () {
-    try {
-      const nonce = await fetch('/wp-admin/admin-ajax.php?action=rest-nonce', {
-        credentials: 'same-origin'
-      }).then(r => r.text());
-      if (!nonce) return null;
-      await fetch('/wp-json/wp/v2/users/me', {
-        method: 'GET',
-        credentials: 'same-origin',
-        headers: { 'X-WP-Nonce': nonce }
-      }).then(r => r.json());
-      return nonce;
-    } catch (err) {
-      console.log('Failed to retrieve nonce', err);
-      return null;
-    }
+export async function getNonce() {
+  try {
+    const nonce = await fetch('/wp-admin/admin-ajax.php?action=rest-nonce', {
+      credentials: 'same-origin'
+    }).then(r => r.text());
+    if (!nonce) return null;
+    await fetch('/wp-json/wp/v2/users/me', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: { 'X-WP-Nonce': nonce }
+    }).then(r => r.json());
+    return nonce;
+  } catch (err) {
+    console.log('Failed to retrieve nonce', err);
+    return null;
   }
-};
+}


### PR DESCRIPTION
## Summary
- convert `wwwroot/js/wpNonce.js` from global script to ES module
- update `WpNonceJsInterop` to load the module via `import`
- remove the old script tag from `index.html`

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68788b6b5d908322b317771fa0eb7a80