### PR TITLE
Convert wpEndpointSync to ES module

### DIFF
--- a/Data/WpEndpointSyncJsInterop.cs
+++ b/Data/WpEndpointSyncJsInterop.cs
@@ -1,0 +1,51 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpEndpointSyncJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public WpEndpointSyncJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/wpEndpointSync.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask RegisterAsync(DotNetObjectReference<object> dotnet)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("register", dotnet);
+    }
+
+    public async ValueTask UnregisterAsync()
+    {
+        if (_module != null)
+        {
+            await _module.InvokeVoidAsync("unregister");
+        }
+    }
+
+    public async ValueTask SetAsync(string value)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("set", value);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -40,13 +40,15 @@
     private IJSRuntime JS { get; set; } = default!;
     [Inject]
     private WpNonceJsInterop NonceJs { get; set; } = default!;
+    [Inject]
+    private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
 
     private string? currentEndpoint;
     private string? currentUsername;
     private const string HostInWpKey = "hostInWp";
     private bool hostInWp = true;
     private string? nonceMessage;
-    private DotNetObjectReference<MainLayout>? _objRef;
+    private DotNetObjectReference<object>? _objRef;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -86,8 +88,8 @@
 
         if (firstRender)
         {
-            _objRef = DotNetObjectReference.Create(this);
-            await JS.InvokeVoidAsync("wpEndpointSync.register", _objRef);
+            _objRef = DotNetObjectReference.Create<object>(this);
+            await EndpointSyncJs.RegisterAsync(_objRef);
             if (hostInWp)
             {
                 await FetchNonce();
@@ -167,7 +169,7 @@
     {
         if (_objRef != null)
         {
-            await JS.InvokeVoidAsync("wpEndpointSync.unregister");
+            await EndpointSyncJs.UnregisterAsync();
             _objRef.Dispose();
         }
     }

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -182,6 +182,8 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
 
     [Inject]
     private IJSRuntime JS { get; set; } = default!;
+    [Inject]
+    private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
@@ -332,7 +334,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                     var root = baseUri.ToString().TrimEnd('/');
                     verifiedEndpoint = root;
                     userUrl = root;
-                    await JS.InvokeVoidAsync("wpEndpointSync.set", root);
+                    await EndpointSyncJs.SetAsync(root);
 
                     var siteInfo = await LoadSiteInfoAsync();
                     if (!siteInfo.ContainsKey(root))

--- a/Program.cs
+++ b/Program.cs
@@ -29,6 +29,7 @@ namespace BlazorWP
             builder.Services.AddScoped<JwtService>();
             builder.Services.AddScoped<UploadPdfJsInterop>();
             builder.Services.AddScoped<WpNonceJsInterop>();
+            builder.Services.AddScoped<WpEndpointSyncJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -34,7 +34,6 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="js/storageUtils.js"></script>
-    <script src="js/wpEndpointSync.js"></script>
     <script src="js/tinyMceConfig.js"></script>
     <script src="js/wpMedia.js"></script>
 </body>

--- a/wwwroot/js/wpEndpointSync.js
+++ b/wwwroot/js/wpEndpointSync.js
@@ -1,25 +1,25 @@
-window.wpEndpointSync = (function () {
-  let dotNetHelper = null;
-  function handleStorage(e) {
-    if (e.key === 'wpEndpoint' && dotNetHelper) {
-      dotNetHelper.invokeMethodAsync('UpdateEndpoint', e.newValue);
-    }
+let dotNetHelper = null;
+
+function handleStorage(e) {
+  if (e.key === 'wpEndpoint' && dotNetHelper) {
+    dotNetHelper.invokeMethodAsync('UpdateEndpoint', e.newValue);
   }
-  return {
-    register: function (dotnet) {
-      dotNetHelper = dotnet;
-      window.addEventListener('storage', handleStorage);
-      dotnet.invokeMethodAsync('UpdateEndpoint', localStorage.getItem('wpEndpoint'));
-    },
-    unregister: function () {
-      window.removeEventListener('storage', handleStorage);
-      dotNetHelper = null;
-    },
-    set: function (value) {
-      localStorage.setItem('wpEndpoint', value);
-      if (dotNetHelper) {
-        dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
-      }
-    }
-  };
-})();
+}
+
+export function register(dotnet) {
+  dotNetHelper = dotnet;
+  window.addEventListener('storage', handleStorage);
+  dotnet.invokeMethodAsync('UpdateEndpoint', localStorage.getItem('wpEndpoint'));
+}
+
+export function unregister() {
+  window.removeEventListener('storage', handleStorage);
+  dotNetHelper = null;
+}
+
+export function set(value) {
+  localStorage.setItem('wpEndpoint', value);
+  if (dotNetHelper) {
+    dotNetHelper.invokeMethodAsync('UpdateEndpoint', value);
+  }
+}


### PR DESCRIPTION
## Summary
- add `WpEndpointSyncJsInterop` for module-based JS interop
- convert `wpEndpointSync.js` to an ES module
- register new JS service in `Program.cs`
- use the service in `MainLayout` and `Home` pages
- remove old script include from `index.html`

## Testing
- `dotnet build -c Release` *(fails: NETSDK1045, .NET 9 SDK not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68788d70faec83229c40d83bd410df4d