### PR TITLE
Add LocalStorage service via JS module

### DIFF
--- a/Data/LocalStorageJsInterop.cs
+++ b/Data/LocalStorageJsInterop.cs
@@ -1,0 +1,55 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class LocalStorageJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public LocalStorageJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/storageUtils.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask<string[]> KeysAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string[]>("keys");
+    }
+
+    public async ValueTask<LocalStorageItemInfo> ItemInfoAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<LocalStorageItemInfo>("itemInfo", key);
+    }
+
+    public async ValueTask DeleteAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("deleteItem", key);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+
+    public class LocalStorageItemInfo
+    {
+        public string? Value { get; set; }
+        public string? LastUpdated { get; set; }
+    }
+}

--- a/Pages/DataStorage.razor
+++ b/Pages/DataStorage.razor
@@ -1,5 +1,5 @@
 @page "/data-storage"
-@inject IJSRuntime JS
+@inject LocalStorageJsInterop StorageJs
 
 <PageTitle>Data Storage</PageTitle>
 
@@ -50,10 +50,10 @@ else
     protected override async Task OnInitializedAsync()
     {
         items = new();
-        var keys = await JS.InvokeAsync<string[]>("blazorwpStorage.keys");
+        var keys = await StorageJs.KeysAsync();
         foreach (var key in keys)
         {
-            var info = await JS.InvokeAsync<ItemInfo>("blazorwpStorage.itemInfo", key);
+            var info = await StorageJs.ItemInfoAsync(key);
             items.Add(new StoredItem
             {
                 Key = key,
@@ -68,13 +68,8 @@ else
         {
             items.RemoveAll(i => i.Key == key);
         }
-        await JS.InvokeVoidAsync("blazorwpStorage.delete", key);
+        await StorageJs.DeleteAsync(key);
         await InvokeAsync(StateHasChanged);
-    }
-
-    private class ItemInfo
-    {
-        public string? Value { get; set; }
     }
 
     private class StoredItem

--- a/Program.cs
+++ b/Program.cs
@@ -30,6 +30,7 @@ namespace BlazorWP
             builder.Services.AddScoped<UploadPdfJsInterop>();
             builder.Services.AddScoped<WpNonceJsInterop>();
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
+            builder.Services.AddScoped<LocalStorageJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -33,7 +33,6 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="js/storageUtils.js"></script>
     <script src="js/tinyMceConfig.js"></script>
     <script src="js/wpMedia.js"></script>
 </body>

--- a/wwwroot/js/storageUtils.js
+++ b/wwwroot/js/storageUtils.js
@@ -1,20 +1,23 @@
-window.blazorwpStorage = {
-  keys: () => Object.keys(window.localStorage),
-  itemInfo: key => {
-    const value = window.localStorage.getItem(key);
-    let ts = window.localStorage.getItem(key + '_timestamp');
-    if (!ts && value) {
-      try {
-        const obj = JSON.parse(value);
-        if (obj && typeof obj === 'object' && obj.lastUpdated) {
-          ts = obj.lastUpdated;
-        }
-      } catch { }
-    }
-    return { value: value, lastUpdated: ts };
-  },
-  delete: key => {
-    window.localStorage.removeItem(key);
-    window.localStorage.removeItem(key + '_timestamp');
+export function keys() {
+  return Object.keys(window.localStorage);
+}
+
+export function itemInfo(key) {
+  const value = window.localStorage.getItem(key);
+  let ts = window.localStorage.getItem(key + '_timestamp');
+  if (!ts && value) {
+    try {
+      const obj = JSON.parse(value);
+      if (obj && typeof obj === 'object' && obj.lastUpdated) {
+        ts = obj.lastUpdated;
+      }
+    } catch { }
   }
-};
+  return { value: value, lastUpdated: ts };
+}
+
+export function deleteItem(key) {
+  window.localStorage.removeItem(key);
+  window.localStorage.removeItem(key + '_timestamp');
+}
+


### PR DESCRIPTION
## Summary
- convert `storageUtils.js` to an ES module
- implement `LocalStorageJsInterop` to load the module
- update DataStorage page to use the new service
- register the service in `Program.cs`
- remove the old script tag from `index.html`

## Testing
- `dotnet build` *(fails: NETSDK1045 - current SDK does not support net9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6878943f8ab483228e9ab67490812c0a