### PR TITLE
Convert wpMedia.js to DI service

### DIFF
--- a/Data/WpMediaJsInterop.cs
+++ b/Data/WpMediaJsInterop.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class WpMediaJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public WpMediaJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/wpMedia.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask InitMediaPageAsync(ElementReference iframeEl, ElementReference overlayEl)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("initMediaPage", iframeEl, overlayEl);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Pages/Media.razor
+++ b/Pages/Media.razor
@@ -1,5 +1,5 @@
 @page "/media"
-@inject IJSRuntime JS
+@inject WpMediaJsInterop MediaJs
 
     <h3 id="media-library-label" class="px-4 mb-2">Media Library</h3>
 
@@ -19,8 +19,13 @@
   {
     if (firstRender)
     {
-      await JS.InvokeVoidAsync("wpMedia.initMediaPage", iframeEl, overlayEl);
+      await MediaJs.InitMediaPageAsync(iframeEl, overlayEl);
     }
+  }
+
+  public async ValueTask DisposeAsync()
+  {
+    await MediaJs.DisposeAsync();
   }
 
 

--- a/Program.cs
+++ b/Program.cs
@@ -31,6 +31,7 @@ namespace BlazorWP
             builder.Services.AddScoped<WpNonceJsInterop>();
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
+            builder.Services.AddScoped<WpMediaJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -34,7 +34,6 @@
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
     <script src="js/tinyMceConfig.js"></script>
-    <script src="js/wpMedia.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/wpMedia.js
+++ b/wwwroot/js/wpMedia.js
@@ -1,13 +1,12 @@
-window.wpMedia = {
-  initMediaPage: function(iframeEl, overlayEl) {
-    console.log("↪ wpMedia.initMediaPage called");
+export function initMediaPage(iframeEl, overlayEl) {
+  console.log("↪ wpMedia.initMediaPage called");
 
-    // 1) hide the overlay once the iframe really loads
-    iframeEl.addEventListener("load", () => {
-      try {
-        const doc = iframeEl.contentDocument || iframeEl.contentWindow.document;
-        const style = doc.createElement("style");
-        style.textContent = `
+  // 1) hide the overlay once the iframe really loads
+  iframeEl.addEventListener("load", () => {
+    try {
+      const doc = iframeEl.contentDocument || iframeEl.contentWindow.document;
+      const style = doc.createElement("style");
+      style.textContent = `
           #wpadminbar, #adminmenumain, #adminmenuwrap, #wpfooter, .wrap > h1 {
             display: none!important;
           }
@@ -17,53 +16,52 @@ window.wpMedia = {
             height:100%!important;
           }
         `;
-        doc.head.appendChild(style);
-      } catch (e) {
-        console.warn("Failed to inject CSS:", e);
-      }
-
-      // hide the yellow overlay
-      overlayEl.style.display = "none";
-
-      // measure distance from top of PAGE to top of iframe
-      const rect          = iframeEl.getBoundingClientRect();
-      const pageOffsetTop = rect.top + window.scrollY;
-      console.log(`Distance from top of page to iframe top: ${pageOffsetTop}px`);
-    });
-
-    // 2) wire up resizing for both iframe and overlay
-    function adjustMedia() {
-      if (!iframeEl) return;
-
-      // measure iframe position and size
-      const rect           = iframeEl.getBoundingClientRect();
-      const pageOffsetTop  = rect.top + window.scrollY;
-      const pageOffsetLeft = rect.left + window.scrollX;
-
-      // compute new height to fill remaining viewport
-      const h = window.innerHeight - pageOffsetTop;
-
-      // resize the iframe
-      iframeEl.style.height = h + "px";
-
-      // position and size the overlay to match the iframe
-      overlayEl.style.position = "absolute";
-      overlayEl.style.top      = pageOffsetTop  + "px";
-      overlayEl.style.left     = pageOffsetLeft + "px";
-      overlayEl.style.width    = rect.width     + "px";
-      overlayEl.style.height   = h               + "px";
-
-      console.log("↪ resized iframe to", h, "and overlay to", {
-        top: overlayEl.style.top,
-        left: overlayEl.style.left,
-        width: overlayEl.style.width,
-        height: overlayEl.style.height
-      });
+      doc.head.appendChild(style);
+    } catch (e) {
+      console.warn("Failed to inject CSS:", e);
     }
 
-    // listen for window resizes and adjust accordingly
-    window.addEventListener("resize", adjustMedia);
-    // initial sizing
-    adjustMedia();
+    // hide the yellow overlay
+    overlayEl.style.display = "none";
+
+    // measure distance from top of PAGE to top of iframe
+    const rect = iframeEl.getBoundingClientRect();
+    const pageOffsetTop = rect.top + window.scrollY;
+    console.log(`Distance from top of page to iframe top: ${pageOffsetTop}px`);
+  });
+
+  // 2) wire up resizing for both iframe and overlay
+  function adjustMedia() {
+    if (!iframeEl) return;
+
+    // measure iframe position and size
+    const rect = iframeEl.getBoundingClientRect();
+    const pageOffsetTop = rect.top + window.scrollY;
+    const pageOffsetLeft = rect.left + window.scrollX;
+
+    // compute new height to fill remaining viewport
+    const h = window.innerHeight - pageOffsetTop;
+
+    // resize the iframe
+    iframeEl.style.height = h + "px";
+
+    // position and size the overlay to match the iframe
+    overlayEl.style.position = "absolute";
+    overlayEl.style.top = pageOffsetTop + "px";
+    overlayEl.style.left = pageOffsetLeft + "px";
+    overlayEl.style.width = rect.width + "px";
+    overlayEl.style.height = h + "px";
+
+    console.log("↪ resized iframe to", h, "and overlay to", {
+      top: overlayEl.style.top,
+      left: overlayEl.style.left,
+      width: overlayEl.style.width,
+      height: overlayEl.style.height
+    });
   }
-};
+
+  // listen for window resizes and adjust accordingly
+  window.addEventListener("resize", adjustMedia);
+  // initial sizing
+  adjustMedia();
+}


### PR DESCRIPTION
## Summary
- convert `wpMedia.js` to an ES module
- provide `WpMediaJsInterop` DI service
- update `Media` page to use DI service
- register service in the app and remove old script tag

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878a75b146c832293babf6200e273ac