### PR TITLE
Convert tinyMceConfig to DI service

### DIFF
--- a/Data/TinyMceJsInterop.cs
+++ b/Data/TinyMceJsInterop.cs
@@ -1,0 +1,42 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class TinyMceJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public TinyMceJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/tinyMceConfig.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        await GetModuleAsync();
+    }
+
+    public async ValueTask SetMediaSourceAsync(string? url)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("setTinyMediaSource", url);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -22,7 +22,7 @@ public partial class Edit
             await JS.InvokeVoidAsync("localStorage.setItem", "mediaSource", selectedMediaSource);
         }
         //Console.WriteLine($"[OnMediaSourceChanged] source='{selectedMediaSource}'");
-        await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
+        await TinyJs.SetMediaSourceAsync(selectedMediaSource);
     }
 
     private void OnTitleChanged()

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -14,6 +14,7 @@ public partial class Edit
     protected override async Task OnInitializedAsync()
     {
         //Console.WriteLine("[OnInitializedAsync] starting");
+        await TinyJs.InitializeAsync();
         var draftsJson = await JS.InvokeAsync<string?>("localStorage.getItem", DraftsKey);
         DraftInfo? latestDraft = null;
         if (!string.IsNullOrEmpty(draftsJson))
@@ -92,7 +93,7 @@ public partial class Edit
             selectedMediaSource = await JS.InvokeAsync<string?>("localStorage.getItem", "mediaSource");
             if (!string.IsNullOrEmpty(selectedMediaSource))
             {
-                await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
+                await TinyJs.SetMediaSourceAsync(selectedMediaSource);
             }
             if (client != null)
             {

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -7,6 +7,7 @@
 @inject IJSRuntime JS
 @inject JwtService JwtService
 @inject AuthMessageHandler AuthHandler
+@inject TinyMceJsInterop TinyJs
 @implements IAsyncDisposable
 
 <PageTitle>Edit</PageTitle>

--- a/Pages/Edit.razor.cs
+++ b/Pages/Edit.razor.cs
@@ -98,6 +98,6 @@ public partial class Edit : IAsyncDisposable
 
     public ValueTask DisposeAsync()
     {
-        return ValueTask.CompletedTask;
+        return TinyJs.DisposeAsync();
     }
 }

--- a/Program.cs
+++ b/Program.cs
@@ -32,6 +32,7 @@ namespace BlazorWP
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
+            builder.Services.AddScoped<TinyMceJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();

--- a/wwwroot/index.html
+++ b/wwwroot/index.html
@@ -33,7 +33,6 @@
         <span class="dismiss">🗙</span>
     </div>
     <script src="_framework/blazor.webassembly.js"></script>
-    <script src="js/tinyMceConfig.js"></script>
 </body>
 
 </html>

--- a/wwwroot/js/tinyMceConfig.js
+++ b/wwwroot/js/tinyMceConfig.js
@@ -1,5 +1,5 @@
-// Classic script for TinyMCE.Blazor to read via JsConfSrc
-window.myTinyMceConfig = {
+// Classic script for TinyMCE.Blazor converted to ESM
+const myTinyMceConfig = {
   promotion: false,
   branding: false,
   statusbar: true,
@@ -109,31 +109,33 @@ window.myTinyMceConfig = {
   }
 };
 
-window.setTinyMediaSource = function (url) {
-  window.myTinyMceConfig.mediaSource = url || null;
-};
+window.myTinyMceConfig = myTinyMceConfig;
 
-window.setTinyEditorContent = function (html) {
+export function setTinyMediaSource(url) {
+  myTinyMceConfig.mediaSource = url || null;
+}
+
+export function setTinyEditorContent(html) {
   if (window.tinymce && tinymce.get('articleEditor')) {
     tinymce.get('articleEditor').setContent(html || '');
   }
-};
+}
 
-window.getTinyEditorContent = function () {
+export function getTinyEditorContent() {
   if (window.tinymce && tinymce.get('articleEditor')) {
     return tinymce.get('articleEditor').getContent();
   }
   return '';
-};
+}
 
-window.getTinyEditorContentLength = function () {
+export function getTinyEditorContentLength() {
   if (window.tinymce && tinymce.get('articleEditor')) {
     return tinymce.get('articleEditor').getContent().length;
   }
   return 0;
-};
+}
 
-window.registerTinyEditorCallbacks = function (dotNetHelper) {
+export function registerTinyEditorCallbacks(dotNetHelper) {
   if (window.tinymce && tinymce.get('articleEditor')) {
     const editor = tinymce.get('articleEditor');
     editor.on('blur', function () {
@@ -145,4 +147,4 @@ window.registerTinyEditorCallbacks = function (dotNetHelper) {
     };
     editor.on('change', changeHandler);
   }
-};
+}


### PR DESCRIPTION
## Summary
- convert `tinyMceConfig.js` to an ES module
- provide new DI service `TinyMceJsInterop`
- register and use the service in the editor page

## Testing
- `dotnet build` *(fails: NETSDK1045 - .NET 9 SDK missing)*

------
https://chatgpt.com/codex/tasks/task_e_6878ae6f7ff48322833d55e34e1f1ddf