### PR TITLE
Replace raw JS interop with storage service

### DIFF
--- a/Data/AuthMessageHandler.cs
+++ b/Data/AuthMessageHandler.cs
@@ -6,14 +6,14 @@ namespace BlazorWP;
 public class AuthMessageHandler : DelegatingHandler
 {
     private readonly JwtService _jwtService;
-    private readonly IJSRuntime _js;
+    private readonly LocalStorageJsInterop _storage;
     private readonly WpNonceJsInterop _nonceJs;
     private const string HostInWpKey = "hostInWp";
 
-    public AuthMessageHandler(JwtService jwtService, IJSRuntime js, WpNonceJsInterop nonceJs)
+    public AuthMessageHandler(JwtService jwtService, LocalStorageJsInterop storage, WpNonceJsInterop nonceJs)
     {
         _jwtService = jwtService;
-        _js = js;
+        _storage = storage;
         _nonceJs = nonceJs;
         InnerHandler = new HttpClientHandler();
     }
@@ -33,7 +33,7 @@ public class AuthMessageHandler : DelegatingHandler
 
     protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
-        var hostPref = await _js.InvokeAsync<string?>("localStorage.getItem", HostInWpKey);
+        var hostPref = await _storage.GetItemAsync(HostInWpKey);
         var useNonce = !string.IsNullOrEmpty(hostPref) && bool.TryParse(hostPref, out var hv) && hv;
 
         if (useNonce)

--- a/Data/SessionStorageJsInterop.cs
+++ b/Data/SessionStorageJsInterop.cs
@@ -1,0 +1,49 @@
+using Microsoft.JSInterop;
+
+namespace BlazorWP;
+
+public class SessionStorageJsInterop : IAsyncDisposable
+{
+    private readonly IJSRuntime _jsRuntime;
+    private IJSObjectReference? _module;
+
+    public SessionStorageJsInterop(IJSRuntime jsRuntime)
+    {
+        _jsRuntime = jsRuntime;
+    }
+
+    private async ValueTask<IJSObjectReference> GetModuleAsync()
+    {
+        if (_module == null)
+        {
+            _module = await _jsRuntime.InvokeAsync<IJSObjectReference>("import", "./js/sessionStorageUtils.js");
+        }
+        return _module;
+    }
+
+    public async ValueTask<string?> GetItemAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string?>("getItem", key);
+    }
+
+    public async ValueTask SetItemAsync(string key, string value)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("setItem", key, value);
+    }
+
+    public async ValueTask DeleteAsync(string key)
+    {
+        var module = await GetModuleAsync();
+        await module.InvokeVoidAsync("deleteItem", key);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        if (_module != null)
+        {
+            await _module.DisposeAsync();
+        }
+    }
+}

--- a/Layout/MainLayout.razor
+++ b/Layout/MainLayout.razor
@@ -37,7 +37,7 @@
 
 @code {
     [Inject]
-    private IJSRuntime JS { get; set; } = default!;
+    private LocalStorageJsInterop StorageJs { get; set; } = default!;
     [Inject]
     private WpNonceJsInterop NonceJs { get; set; } = default!;
     [Inject]
@@ -52,13 +52,13 @@
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         string? username = null;
         if (!string.IsNullOrEmpty(endpoint))
         {
             username = await GetUsernameAsync(endpoint);
         }
-        var hostPref = await JS.InvokeAsync<string?>("localStorage.getItem", HostInWpKey);
+        var hostPref = await StorageJs.GetItemAsync(HostInWpKey);
 
         var changed = false;
         if (endpoint != currentEndpoint)
@@ -114,7 +114,7 @@
 
     private async Task<string?> GetUsernameAsync(string endpoint)
     {
-        var json = await JS.InvokeAsync<string?>("localStorage.getItem", "siteinfo");
+        var json = await StorageJs.GetItemAsync("siteinfo");
         if (string.IsNullOrEmpty(json))
         {
             return null;
@@ -138,7 +138,7 @@
 
     private async Task OnHostInWpChanged()
     {
-        await JS.InvokeVoidAsync("localStorage.setItem", HostInWpKey, hostInWp.ToString().ToLowerInvariant());
+        await StorageJs.SetItemAsync(HostInWpKey, hostInWp.ToString().ToLowerInvariant());
         if (hostInWp)
         {
             await FetchNonce();

--- a/Pages/ApiViewerAnt.razor
+++ b/Pages/ApiViewerAnt.razor
@@ -1,7 +1,7 @@
 @page "/api-ant"
 @using System.Text.Json
 @inject HttpClient Http
-@inject IJSRuntime JS
+@inject LocalStorageJsInterop StorageJs
 
 <PageTitle>Ant Design API Viewer</PageTitle>
 
@@ -45,14 +45,14 @@ else
     private async Task ToggleFavorite(AntJsonNode node)
     {
         //Console.WriteLine($"[ToggleFavorite] Toggling {node.Path}");
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         //Console.WriteLine($"[ToggleFavorite] Endpoint: {endpoint}");
         if (string.IsNullOrEmpty(endpoint))
         {
             return;
         }
 
-        var json = await JS.InvokeAsync<string?>("localStorage.getItem", "favoriteApis");
+        var json = await StorageJs.GetItemAsync("favoriteApis");
         //Console.WriteLine($"[ToggleFavorite] Current JSON: {json}");
         Dictionary<string, List<string>> data;
         if (!string.IsNullOrEmpty(json))
@@ -91,13 +91,13 @@ else
         }
 
         var serialized = JsonSerializer.Serialize(data);
-        await JS.InvokeVoidAsync("localStorage.setItem", "favoriteApis", serialized);
+        await StorageJs.SetItemAsync("favoriteApis", serialized);
         await InvokeAsync(StateHasChanged);
     }
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         if (string.IsNullOrEmpty(endpoint))
         {
             loading = false;
@@ -124,7 +124,7 @@ else
             var root = BuildNode(doc.RootElement, "root", "");
             rootNodes = root.Children;
 
-            var favJson = await JS.InvokeAsync<string?>("localStorage.getItem", "favoriteApis");
+            var favJson = await StorageJs.GetItemAsync("favoriteApis");
             if (!string.IsNullOrEmpty(favJson) &&
                 JsonSerializer.Deserialize<Dictionary<string, List<string>>>(favJson) is { } favData &&
                 favData.TryGetValue(endpoint, out var favs))

--- a/Pages/Edit.Drafts.cs
+++ b/Pages/Edit.Drafts.cs
@@ -229,7 +229,7 @@ public partial class Edit
 
     private async Task<List<DraftInfo>> LoadDraftStatesAsync()
     {
-        var json = await JS.InvokeAsync<string?>("localStorage.getItem", DraftsKey);
+        var json = await StorageJs.GetItemAsync(DraftsKey);
         if (!string.IsNullOrEmpty(json))
         {
             try
@@ -245,7 +245,7 @@ public partial class Edit
     private async Task SaveDraftStatesAsync(List<DraftInfo> list)
     {
         var json = JsonSerializer.Serialize(list);
-        await JS.InvokeVoidAsync("localStorage.setItem", DraftsKey, json);
+        await StorageJs.SetItemAsync(DraftsKey, json);
     }
 
     private async Task RemoveLocalDraftAsync(int? id)

--- a/Pages/Edit.Events.cs
+++ b/Pages/Edit.Events.cs
@@ -15,11 +15,11 @@ public partial class Edit
     {
         if (string.IsNullOrEmpty(selectedMediaSource))
         {
-            await JS.InvokeVoidAsync("localStorage.removeItem", "mediaSource");
+            await StorageJs.DeleteAsync("mediaSource");
         }
         else
         {
-            await JS.InvokeVoidAsync("localStorage.setItem", "mediaSource", selectedMediaSource);
+            await StorageJs.SetItemAsync("mediaSource", selectedMediaSource);
         }
         //Console.WriteLine($"[OnMediaSourceChanged] source='{selectedMediaSource}'");
         await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
@@ -66,7 +66,7 @@ public partial class Edit
 
     private async Task OnShowTrashedChanged()
     {
-        await JS.InvokeVoidAsync("localStorage.setItem", ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
+        await StorageJs.SetItemAsync(ShowTrashedKey, showTrashed.ToString().ToLowerInvariant());
         // Only update the stored preference. Actual querying happens when
         // the user explicitly clicks the Refresh button.
     }

--- a/Pages/Edit.Lifecycle.cs
+++ b/Pages/Edit.Lifecycle.cs
@@ -14,7 +14,7 @@ public partial class Edit
     protected override async Task OnInitializedAsync()
     {
         //Console.WriteLine("[OnInitializedAsync] starting");
-        var draftsJson = await JS.InvokeAsync<string?>("localStorage.getItem", DraftsKey);
+        var draftsJson = await StorageJs.GetItemAsync(DraftsKey);
         DraftInfo? latestDraft = null;
         if (!string.IsNullOrEmpty(draftsJson))
         {
@@ -44,7 +44,7 @@ public partial class Edit
             hasPersistedContent = false;
         }
 
-        var trashedSetting = await JS.InvokeAsync<string?>("localStorage.getItem", ShowTrashedKey);
+        var trashedSetting = await StorageJs.GetItemAsync(ShowTrashedKey);
         if (!string.IsNullOrEmpty(trashedSetting) && bool.TryParse(trashedSetting, out var trashed))
         {
             showTrashed = trashed;
@@ -89,7 +89,7 @@ public partial class Edit
         {
             //Console.WriteLine("[OnAfterRenderAsync] firstRender");
             mediaSources = await JwtService.GetSiteInfoKeysAsync();
-            selectedMediaSource = await JS.InvokeAsync<string?>("localStorage.getItem", "mediaSource");
+            selectedMediaSource = await StorageJs.GetItemAsync("mediaSource");
             if (!string.IsNullOrEmpty(selectedMediaSource))
             {
                 await JS.InvokeVoidAsync("setTinyMediaSource", selectedMediaSource);
@@ -109,7 +109,7 @@ public partial class Edit
 
     private async Task SetupWordPressClientAsync()
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         if (string.IsNullOrEmpty(endpoint))
         {
             client = null;

--- a/Pages/Edit.razor
+++ b/Pages/Edit.razor
@@ -6,6 +6,7 @@
 @inject HttpClient Http
 @inject IJSRuntime JS
 @inject JwtService JwtService
+@inject LocalStorageJsInterop StorageJs
 @inject AuthMessageHandler AuthHandler
 @implements IAsyncDisposable
 

--- a/Pages/Home.razor
+++ b/Pages/Home.razor
@@ -181,7 +181,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private HttpClient Http { get; set; } = default!;
 
     [Inject]
-    private IJSRuntime JS { get; set; } = default!;
+    private LocalStorageJsInterop StorageJs { get; set; } = default!;
     [Inject]
     private WpEndpointSyncJsInterop EndpointSyncJs { get; set; } = default!;
 
@@ -189,7 +189,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     {
         if (firstRender)
         {
-            verifiedEndpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+            verifiedEndpoint = await StorageJs.GetItemAsync("wpEndpoint");
             userUrl = verifiedEndpoint;
             if (!string.IsNullOrEmpty(verifiedEndpoint))
             {
@@ -203,13 +203,13 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                 }
                 else
                 {
-                    jwtToken = await JS.InvokeAsync<string?>("localStorage.getItem", "jwtToken");
+                    jwtToken = await StorageJs.GetItemAsync("jwtToken");
                     jwtDecoded = DecodeJwt(jwtToken);
                 }
             }
             else
             {
-                jwtToken = await JS.InvokeAsync<string?>("localStorage.getItem", "jwtToken");
+                jwtToken = await StorageJs.GetItemAsync("jwtToken");
                 jwtDecoded = DecodeJwt(jwtToken);
             }
             await LoadFavorites();
@@ -223,7 +223,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
         knownSites.Clear();
 
         Dictionary<string, List<string>>? favData = null;
-        var favJson = await JS.InvokeAsync<string?>("localStorage.getItem", "favoriteApis");
+        var favJson = await StorageJs.GetItemAsync("favoriteApis");
         if (!string.IsNullOrEmpty(favJson))
         {
             try
@@ -352,18 +352,18 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
                         jwtDecoded = DecodeJwt(jwtToken);
                         if (!string.IsNullOrEmpty(jwtToken))
                         {
-                            await JS.InvokeVoidAsync("localStorage.setItem", "jwtToken", jwtToken);
+                            await StorageJs.SetItemAsync("jwtToken", jwtToken);
                         }
                         else
                         {
-                            await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+                            await StorageJs.DeleteAsync("jwtToken");
                         }
                     }
                     else
                     {
                         jwtToken = null;
                         jwtDecoded = null;
-                        await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+                        await StorageJs.DeleteAsync("jwtToken");
                     }
                     await LoadFavorites();
                     status = $"Success! v2 endpoint is {apiEndpoint}";
@@ -604,7 +604,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
 
     private async Task<Dictionary<string, JwtInfo>> LoadSiteInfoAsync()
     {
-        var json = await JS.InvokeAsync<string?>("localStorage.getItem", SiteInfoKey);
+        var json = await StorageJs.GetItemAsync(SiteInfoKey);
         if (string.IsNullOrEmpty(json))
         {
             return new();
@@ -623,7 +623,7 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
     private Task SaveSiteInfoAsync(Dictionary<string, JwtInfo> data)
     {
         var json = JsonSerializer.Serialize(data);
-        return JS.InvokeVoidAsync("localStorage.setItem", SiteInfoKey, json).AsTask();
+        return StorageJs.SetItemAsync(SiteInfoKey, json).AsTask();
     }
 
     private async Task<JwtInfo?> LoadJwtInfoAsync(string endpoint)
@@ -636,16 +636,16 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
 
         // Fallback to old storage formats
         var key = GetJwtInfoKey(endpoint);
-        var json = await JS.InvokeAsync<string?>("localStorage.getItem", key);
+        var json = await StorageJs.GetItemAsync(key);
         if (string.IsNullOrEmpty(json))
         {
             var oldKey = GetOldJwtInfoKey(endpoint);
-            json = await JS.InvokeAsync<string?>("localStorage.getItem", oldKey);
+            json = await StorageJs.GetItemAsync(oldKey);
         }
 
         if (string.IsNullOrEmpty(json))
         {
-            var token = await JS.InvokeAsync<string?>("localStorage.getItem", GetJwtTokenKey(endpoint));
+            var token = await StorageJs.GetItemAsync(GetJwtTokenKey(endpoint));
             if (!string.IsNullOrEmpty(token))
             {
                 info = new JwtInfo { Token = token };
@@ -682,17 +682,17 @@ This token was minted by https://yasuaki.com at 2025-06-19 06:43:23 UTC (15:43 J
 
         if (!string.IsNullOrEmpty(info.Token))
         {
-            await JS.InvokeVoidAsync("localStorage.setItem", "jwtToken", info.Token);
+            await StorageJs.SetItemAsync("jwtToken", info.Token);
         }
         else
         {
-            await JS.InvokeVoidAsync("localStorage.removeItem", "jwtToken");
+            await StorageJs.DeleteAsync("jwtToken");
         }
 
         var oldKey = GetOldJwtInfoKey(endpoint);
-        await JS.InvokeVoidAsync("localStorage.removeItem", oldKey);
-        await JS.InvokeVoidAsync("localStorage.removeItem", GetJwtTokenKey(endpoint));
-        await JS.InvokeVoidAsync("localStorage.removeItem", endpoint);
+        await StorageJs.DeleteAsync(oldKey);
+        await StorageJs.DeleteAsync(GetJwtTokenKey(endpoint));
+        await StorageJs.DeleteAsync(endpoint);
     }
 
     private static string? DecodeJwt(string? token)

--- a/Pages/OAuth.razor
+++ b/Pages/OAuth.razor
@@ -1,7 +1,7 @@
 @page "/oauth"
 @using Microsoft.AspNetCore.WebUtilities
 @inject NavigationManager Nav
-@inject IJSRuntime JS
+@inject SessionStorageJsInterop SessionJs
 @inject IConfiguration Config
 
 <!--
@@ -22,9 +22,9 @@
 else
 {
     <p>Select a provider to begin OAuth login.</p>
-    <button class="btn btn-primary me-2" @onclick="() => StartOAuth(Google)">Google</button>
-    <button class="btn btn-secondary me-2" @onclick="() => StartOAuth(GitHub)">GitHub</button>
-    <button class="btn btn-success" @onclick="() => StartOAuth(Line)">LINE</button>
+    <button class="btn btn-primary me-2" @onclick="async () => await StartOAuth(Google)">Google</button>
+    <button class="btn btn-secondary me-2" @onclick="async () => await StartOAuth(GitHub)">GitHub</button>
+    <button class="btn btn-success" @onclick="async () => await StartOAuth(Line)">LINE</button>
 }
 
 @code {
@@ -59,13 +59,13 @@ else
             "profile openid");
     }
 
-    private void StartOAuth(OAuthProvider provider)
+    private async Task StartOAuth(OAuthProvider provider)
     {
         var pkce = PkceUtil.Create();
         var state = Guid.NewGuid().ToString("N");
         var redirectUri = Nav.BaseUri.TrimEnd('/') + "/oauth";
         var url = provider.BuildAuthorizeUrl(pkce.CodeChallenge, redirectUri, state);
-        JS.InvokeVoidAsync("sessionStorage.setItem", "pkce_" + state, pkce.CodeVerifier);
+        await SessionJs.SetItemAsync("pkce_" + state, pkce.CodeVerifier);
         //Console.WriteLine($"OAuth authorize URL:\n{url}");
 
         Nav.NavigateTo(url, true);

--- a/Pages/PclDemo.razor
+++ b/Pages/PclDemo.razor
@@ -1,5 +1,6 @@
 @page "/pcl-demo"
 @using WordPressPCL
+@inject LocalStorageJsInterop StorageJs
 @inject IJSRuntime JS
 @inject JwtService JwtService
 
@@ -48,7 +49,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         if (string.IsNullOrEmpty(endpoint))
         {
             return;

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -2,7 +2,7 @@
 @using WordPressPCL
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
-@inject IJSRuntime JS
+@inject LocalStorageJsInterop StorageJs
 @inject UploadPdfJsInterop PdfJs
 @inject AuthMessageHandler AuthHandler
 
@@ -44,7 +44,7 @@ else
 
     protected override async Task OnInitializedAsync()
     {
-        var endpoint = await JS.InvokeAsync<string?>("localStorage.getItem", "wpEndpoint");
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         if (string.IsNullOrEmpty(endpoint)) return;
         var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
         var httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };

--- a/Program.cs
+++ b/Program.cs
@@ -31,6 +31,7 @@ namespace BlazorWP
             builder.Services.AddScoped<WpNonceJsInterop>();
             builder.Services.AddScoped<WpEndpointSyncJsInterop>();
             builder.Services.AddScoped<LocalStorageJsInterop>();
+            builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
 
             // 5) Build the host (this hooks up the logging provider)

--- a/wwwroot/js/sessionStorageUtils.js
+++ b/wwwroot/js/sessionStorageUtils.js
@@ -1,0 +1,11 @@
+export function getItem(key) {
+  return window.sessionStorage.getItem(key);
+}
+
+export function setItem(key, value) {
+  window.sessionStorage.setItem(key, value);
+}
+
+export function deleteItem(key) {
+  window.sessionStorage.removeItem(key);
+}


### PR DESCRIPTION
## Summary
- add a SessionStorageJsInterop helper and JS module
- register the new service in DI
- use LocalStorageJsInterop or SessionStorageJsInterop instead of raw JS in pages and services

## Testing
- `apt-get update`
- `apt-get install -y dotnet-sdk-8.0`
- `dotnet build --no-restore` *(fails: NETSDK1045 - .NET 9.0 not supported by installed SDK)*

------
https://chatgpt.com/codex/tasks/task_e_6878c7305a788322b2f62079c015f255