### PR TITLE
Fix property access in PdfDimensions

### DIFF
--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -84,7 +84,7 @@ else
     private void CalculateWpSizes()
     {
         if (pageInfo == null) return;
-        var (w, h) = (pageInfo.Value.Width, pageInfo.Value.Height);
+        var (w, h) = (pageInfo.Width, pageInfo.Height);
         var medium = SoftScale(w, h, 300, 300);
         var mediumLarge = SoftScale(w, h, 768, 0);
         var large = SoftScale(w, h, 1024, 1024);


### PR DESCRIPTION
## Summary
- fix PdfDimensions property access in `UploadPdf.razor`

## Testing
- ❌ `dotnet build --no-restore` *(dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6878e503c1a083229f20ca0b458dcdf1