### PR TITLE
Add preview images for all WP sizes

### DIFF
--- a/Data/UploadPdfJsInterop.cs
+++ b/Data/UploadPdfJsInterop.cs
@@ -2,7 +2,7 @@ using Microsoft.JSInterop;
 
 namespace BlazorWP;
 
-public record PdfDimensions(int Width, int Height);
+public record PdfRenderInfo(int Width, int Height, string DataUrl);
 
 public class UploadPdfJsInterop : IAsyncDisposable
 {
@@ -29,10 +29,16 @@ public class UploadPdfJsInterop : IAsyncDisposable
         await module.InvokeVoidAsync("initialize", canvasId, imgId);
     }
 
-    public async ValueTask<PdfDimensions> RenderFirstPageAsync(DotNetStreamReference streamRef, string canvasId, string imgId)
+    public async ValueTask<PdfRenderInfo> RenderFirstPageAsync(DotNetStreamReference streamRef, string canvasId, string imgId)
     {
         var module = await GetModuleAsync();
-        return await module.InvokeAsync<PdfDimensions>("renderFirstPageFromStream", streamRef, canvasId, imgId);
+        return await module.InvokeAsync<PdfRenderInfo>("renderFirstPageFromStream", streamRef, canvasId, imgId);
+    }
+
+    public async ValueTask<string?> GetCurrentDataUrlAsync()
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string?>("getCurrentDataUrl");
     }
 
     public async ValueTask DisposeAsync()

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -57,6 +57,19 @@ else
                 }
             </tbody>
         </table>
+
+        @if (previewDataUrl != null)
+        {
+            <div class="wp-size-previews d-flex flex-wrap gap-3">
+                @foreach (var s in wpSizes)
+                {
+                    <div class="text-center">
+                        <img src="@previewDataUrl" width="@s.Width" height="@s.Height" class="border" style="object-fit:@(s.Name == "thumbnail" ? "cover" : "contain");" />
+                        <div class="small text-muted">@s.Name</div>
+                    </div>
+                }
+            </div>
+        }
     }
 }
 
@@ -67,7 +80,8 @@ else
     private int uploadProgress;
     private bool isUploading;
     private DotNetStreamReference? _fileStreamRef;
-    private PdfDimensions? pageInfo;
+    private PdfRenderInfo? pageInfo;
+    private string? previewDataUrl;
     private List<WpSize>? wpSizes;
 
     private record WpSize(string Name, int Width, int Height, string CropMode, string Notes);
@@ -126,6 +140,7 @@ else
                 _fileStreamRef,
                 "canvas",
                 "preview");
+            previewDataUrl = pageInfo.DataUrl;
             CalculateWpSizes();
             StateHasChanged();
         }

--- a/Pages/UploadPdf.razor.css
+++ b/Pages/UploadPdf.razor.css
@@ -9,3 +9,8 @@
   justify-content: center;
   overflow: hidden;
 }
+
+.wp-size-previews img {
+  display: block;
+  max-width: 100%;
+}

--- a/wwwroot/js/upload-pdf.js
+++ b/wwwroot/js/upload-pdf.js
@@ -4,6 +4,7 @@ pdfjsLib.GlobalWorkerOptions.workerSrc = './pdf.worker.mjs';
 const cMapBaseUrl = 'libman/pdfjs-dist/cmaps/';
 const cMapPacked = true;
 const { getDocument } = pdfjsLib;
+let lastDataUrl = null;
 
 // Initialize image resizing behavior on component mount
 export function initialize(canvasId, imgId) {
@@ -32,13 +33,19 @@ export async function renderFirstPageFromStream(streamRef, canvasId, imgId) {
   await page.render({ canvasContext: ctx, viewport }).promise;
 
   const outputImg = document.getElementById(imgId);
-  outputImg.src = canvas.toDataURL('image/png');
+  lastDataUrl = canvas.toDataURL('image/png');
+  outputImg.src = lastDataUrl;
   adjustPreview(outputImg);
 
   return {
     width: Math.floor(originalViewport.width),
-    height: Math.floor(originalViewport.height)
+    height: Math.floor(originalViewport.height),
+    dataUrl: lastDataUrl
   };
+}
+
+export function getCurrentDataUrl() {
+  return lastDataUrl;
 }
 
 function adjustPreview(outputImg) {


### PR DESCRIPTION
## Summary
- add data URL support to PDF JS interop
- preview each WordPress image size when selecting a PDF

## Testing
- `dotnet build --no-restore` *(fails: NETSDK1045 - current SDK doesn't support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68796b9eb6c083229ad68843b5ab673e