### PR TITLE
Add preview image bundle upload

### DIFF
--- a/Data/UploadPdfJsInterop.cs
+++ b/Data/UploadPdfJsInterop.cs
@@ -41,6 +41,12 @@ public class UploadPdfJsInterop : IAsyncDisposable
         return await module.InvokeAsync<string?>("getCurrentDataUrl");
     }
 
+    public async ValueTask<string?> GetScaledPreviewAsync(int width, int height, bool cover)
+    {
+        var module = await GetModuleAsync();
+        return await module.InvokeAsync<string?>("getScaledPreview", width, height, cover);
+    }
+
     public async ValueTask DisposeAsync()
     {
         if (_module != null)

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -2,6 +2,10 @@
 @using WordPressPCL
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.JSInterop
+@using System.Net.Http.Headers
+@using System.Text.Json
+@using System.IO
+@using System.Net.Http
 @inject LocalStorageJsInterop StorageJs
 @inject UploadPdfJsInterop PdfJs
 @inject AuthMessageHandler AuthHandler
@@ -58,13 +62,13 @@ else
             </tbody>
         </table>
 
-        @if (previewDataUrl != null)
+        @if (previewDataUrl != null && sizePreviews != null)
         {
             <div class="wp-size-previews d-flex flex-wrap gap-3">
                 @foreach (var s in wpSizes)
                 {
                     <div class="text-center">
-                        <img src="@previewDataUrl" width="@s.Width" height="@s.Height" class="border" style="object-fit:@(s.Name == "thumbnail" ? "cover" : "contain");" />
+                        <img src="@sizePreviews[s.Name]" width="@s.Width" height="@s.Height" class="border" style="object-fit:@(s.Name == "thumbnail" ? "cover" : "contain");" />
                         <div class="small text-muted">@s.Name</div>
                     </div>
                 }
@@ -75,6 +79,7 @@ else
 
 @code {
     private WordPressClient? client;
+    private HttpClient? httpClient;
     private IBrowserFile? _file;
     private string? status;
     private int uploadProgress;
@@ -83,33 +88,26 @@ else
     private PdfRenderInfo? pageInfo;
     private string? previewDataUrl;
     private List<WpSize>? wpSizes;
+    private Dictionary<string, string>? sizePreviews;
 
     private record WpSize(string Name, int Width, int Height, string CropMode, string Notes);
-
-    private static (int width, int height) SoftScale(int w, int h, int maxW, int maxH)
-    {
-        double ratio = 1;
-        if (maxW > 0) ratio = Math.Min(ratio, (double)maxW / w);
-        if (maxH > 0) ratio = Math.Min(ratio, (double)maxH / h);
-        ratio = Math.Min(ratio, 1);
-        return ((int)Math.Round(w * ratio), (int)Math.Round(h * ratio));
-    }
 
     private void CalculateWpSizes()
     {
         if (pageInfo == null) return;
         var (w, h) = (pageInfo.Width, pageInfo.Height);
-        var medium = SoftScale(w, h, 300, 300);
-        var mediumLarge = SoftScale(w, h, 768, 0);
-        var large = SoftScale(w, h, 1024, 1024);
+        double ratio = w >= h ? (double)w / h : (double)h / w;
+        int ScaledHeight(int width) => (int)Math.Round(width / ratio);
+        var longSide = Math.Max(w, h);
+        var shortSide = Math.Min(w, h);
 
         wpSizes = new()
         {
-            new("thumbnail", 150, 150, "hard (exact)", "Square crop by default"),
-            new("medium", medium.width, medium.height, "soft (max)", "Proportional—won’t exceed either axis"),
-            new("medium_large", mediumLarge.width, mediumLarge.height, "soft (max)", "Max width 768, unlimited height"),
-            new("large", large.width, large.height, "soft (max)", "Proportional—won’t exceed either axis"),
-            new("full", w, h, "n/a", "The original uploaded file")
+            new("thumbnail", 150, ScaledHeight(150), "hard (cover)", "Preview thumbnail"),
+            new("medium", 300, ScaledHeight(300), "soft (max)", "Scaled preview"),
+            new("medium_large", 768, ScaledHeight(768), "soft (max)", "Max width 768"),
+            new("large", 1024, ScaledHeight(1024), "soft (max)", "Max width 1024"),
+            new("full", longSide, shortSide, "n/a", "Full first page")
         };
     }
 
@@ -118,7 +116,7 @@ else
         var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
         if (string.IsNullOrEmpty(endpoint)) return;
         var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
-        var httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
+        httpClient = new HttpClient(AuthHandler) { BaseAddress = new Uri(baseUrl) };
         client = new WordPressClient(httpClient);
     }
 
@@ -142,24 +140,65 @@ else
                 "preview");
             previewDataUrl = pageInfo.DataUrl;
             CalculateWpSizes();
+            if (wpSizes != null)
+            {
+                sizePreviews = new();
+                foreach (var s in wpSizes)
+                {
+                    if (s.Name == "full")
+                    {
+                        sizePreviews[s.Name] = previewDataUrl!;
+                        continue;
+                    }
+                    var url = await PdfJs.GetScaledPreviewAsync(s.Width, s.Height, s.Name == "thumbnail");
+                    if (url != null)
+                    {
+                        sizePreviews[s.Name] = url;
+                    }
+                }
+            }
             StateHasChanged();
         }
     }
 
     private async Task UploadAsync()
     {
-        if (client == null || _file == null) return;
+        if (client == null || _file == null || wpSizes == null || sizePreviews == null) return;
         status = null; uploadProgress = 0; isUploading = true;
         try
         {
-            using var stream = _file.OpenReadStream(long.MaxValue);
-            using var progressStream = new ProgressStream(stream, (sent, total) =>
+            var endpoint = new Uri(httpClient!.BaseAddress!, "myplugin/v1/media/bundle");
+            using var form = new MultipartFormDataContent();
+
+            using var pdfStream = _file.OpenReadStream(long.MaxValue);
+            form.Add(new StreamContent(pdfStream), "pdf", _file.Name);
+
+            var dimensions = new Dictionary<string, object?>();
+
+            foreach (var s in wpSizes)
             {
-                uploadProgress = (int)(sent * 100 / total);
-                InvokeAsync(StateHasChanged);
-            });
-            var media = await client.Media.CreateAsync(progressStream, _file.Name, "application/pdf");
-            status = $"Uploaded media ID: {media.Id}";
+                if (!sizePreviews.TryGetValue(s.Name, out var dataUrl)) continue;
+                var base64 = dataUrl[(dataUrl.IndexOf(',') + 1)..];
+                var bytes = Convert.FromBase64String(base64);
+                var imgContent = new ByteArrayContent(bytes);
+                imgContent.Headers.ContentType = new MediaTypeHeaderValue("image/jpeg");
+                form.Add(imgContent, $"previews[{s.Name}]", $"{Path.GetFileNameWithoutExtension(_file.Name)}-{s.Name}.jpg");
+
+                if (s.Name != "full")
+                {
+                    dimensions[s.Name] = new { width = s.Width, height = s.Height };
+                }
+                else
+                {
+                    dimensions[s.Name] = new { };
+                }
+            }
+
+            form.Add(new StringContent(JsonSerializer.Serialize(dimensions)), "dimensions");
+
+            var resp = await httpClient!.PostAsync(endpoint, form);
+            resp.EnsureSuccessStatusCode();
+            status = "Upload complete";
             uploadProgress = 100;
         }
         catch (Exception ex)

--- a/wwwroot/js/upload-pdf.js
+++ b/wwwroot/js/upload-pdf.js
@@ -48,6 +48,42 @@ export function getCurrentDataUrl() {
   return lastDataUrl;
 }
 
+// Return a resized preview data URL using the current rendered page
+export async function getScaledPreview(width, height, cover) {
+  if (!lastDataUrl) return null;
+  const img = new Image();
+  img.src = lastDataUrl;
+  await img.decode();
+
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const ctx = canvas.getContext('2d');
+
+  if (cover) {
+    const srcRatio = img.width / img.height;
+    const dstRatio = width / height;
+    let sx = 0, sy = 0, sw = img.width, sh = img.height;
+    if (srcRatio > dstRatio) {
+      sw = img.height * dstRatio;
+      sx = (img.width - sw) / 2;
+    } else {
+      sh = img.width / dstRatio;
+      sy = (img.height - sh) / 2;
+    }
+    ctx.drawImage(img, sx, sy, sw, sh, 0, 0, width, height);
+  } else {
+    const ratio = Math.min(width / img.width, height / img.height, 1);
+    const dw = img.width * ratio;
+    const dh = img.height * ratio;
+    const dx = (width - dw) / 2;
+    const dy = (height - dh) / 2;
+    ctx.drawImage(img, 0, 0, img.width, img.height, dx, dy, dw, dh);
+  }
+
+  return canvas.toDataURL('image/jpeg');
+}
+
 function adjustPreview(outputImg) {
   if (!outputImg) return;
   const rect = outputImg.getBoundingClientRect();


### PR DESCRIPTION
## Summary
- generate scaled image previews client-side
- expose new JS interop for scaled previews
- show generated previews for each WP size
- upload PDF and previews to custom endpoint with dimension map

## Testing
- `dotnet build -v minimal`

------
https://chatgpt.com/codex/tasks/task_e_68798cf8d7748322b45dd077cf458f49