### PR TITLE
Remove preview thumbnails display

### DIFF
--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -62,18 +62,6 @@ else
             </tbody>
         </table>
 
-        @if (previewDataUrl != null && sizePreviews != null)
-        {
-            <div class="wp-size-previews d-flex flex-wrap gap-3">
-                @foreach (var s in wpSizes)
-                {
-                    <div class="text-center">
-                        <img src="@sizePreviews[s.Name]" width="@s.Width" height="@s.Height" class="border" style="object-fit:@(s.Name == "thumbnail" ? "cover" : "contain");" />
-                        <div class="small text-muted">@s.Name</div>
-                    </div>
-                }
-            </div>
-        }
     }
 }
 

--- a/Pages/UploadPdf.razor.css
+++ b/Pages/UploadPdf.razor.css
@@ -10,7 +10,3 @@
   overflow: hidden;
 }
 
-.wp-size-previews img {
-  display: block;
-  max-width: 100%;
-}


### PR DESCRIPTION
## Summary
- remove small preview thumbnails from UploadPdf page
- drop unused `.wp-size-previews` CSS rule

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6879bc6e3ef08322803cc2fad496d4e9