### PR TITLE
Hide details on upload pdf page

### DIFF
--- a/Pages/UploadPdf.razor.css
+++ b/Pages/UploadPdf.razor.css
@@ -14,3 +14,12 @@
   display: block;
   max-width: 100%;
 }
+
+/* Hide all details except the main preview image */
+#file-input,
+.d-flex.align-items-center.gap-2.mb-3,
+.progress,
+table.table,
+.wp-size-previews {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- hide all info except the preview image on the Upload PDF page

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879cf09d5648322a943dfe525806137