### PR TITLE
Remove unused parameter from upload pdf init

### DIFF
--- a/Data/UploadPdfJsInterop.cs
+++ b/Data/UploadPdfJsInterop.cs
@@ -23,10 +23,10 @@ public class UploadPdfJsInterop : IAsyncDisposable
         return _module;
     }
 
-    public async ValueTask InitializeAsync(string canvasId, string imgId)
+    public async ValueTask InitializeAsync(string imgId)
     {
         var module = await GetModuleAsync();
-        await module.InvokeVoidAsync("initialize", canvasId, imgId);
+        await module.InvokeVoidAsync("initialize", imgId);
     }
 
     public async ValueTask<PdfRenderInfo> RenderFirstPageAsync(DotNetStreamReference streamRef, string canvasId, string imgId)

--- a/Pages/UploadPdf.razor
+++ b/Pages/UploadPdf.razor
@@ -132,7 +132,7 @@ else
     {
         if (firstRender)
         {
-            await PdfJs.InitializeAsync("canvas", "preview");
+            await PdfJs.InitializeAsync("preview");
         }
     }
 

--- a/wwwroot/js/upload-pdf.js
+++ b/wwwroot/js/upload-pdf.js
@@ -11,7 +11,7 @@ const { getDocument } = pdfjsLib;
 let lastDataUrl = null;
 
 // Initialize image resizing behavior on component mount
-export function initialize(canvasId, imgId) {
+export function initialize(imgId) {
   const outputImg = document.getElementById(imgId);
   window.addEventListener('resize', () => adjustPreview(outputImg));
   outputImg?.addEventListener('load', () => adjustPreview(outputImg));


### PR DESCRIPTION
## Summary
- remove the `canvasId` argument from JS `initialize`
- update `UploadPdfJsInterop` and `UploadPdf.razor` to match new signature

## Testing
- `dotnet build --no-restore` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6879e7fecc948322a14a8156440f88e1