### PR TITLE
Add WordPress user info page

### DIFF
--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -79,6 +79,11 @@
                 <span class="bi bi-image" aria-hidden="true"></span> Media Library
             </NavLink>
         </div>
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="user-info">
+                <span class="bi bi-person-circle" aria-hidden="true"></span> User Info
+            </NavLink>
+        </div>
     </nav>
 </div>
 

--- a/Pages/UserInfo.razor
+++ b/Pages/UserInfo.razor
@@ -1,0 +1,67 @@
+@page "/user-info"
+@using WordPressPCL
+@using WordPressPCL.Models
+@inject LocalStorageJsInterop StorageJs
+@inject JwtService JwtService
+
+<PageTitle>User Info</PageTitle>
+
+<h1>User Info</h1>
+
+@if (client == null)
+{
+    <p>No WordPress endpoint verified. Visit <NavLink href="/">Home</NavLink> first.</p>
+}
+else if (!string.IsNullOrEmpty(error))
+{
+    <p class="text-danger">@error</p>
+}
+else if (user == null)
+{
+    <p><em>Loading...</em></p>
+}
+else
+{
+    <dl>
+        <dt>Username</dt>
+        <dd>@user.UserName</dd>
+        <dt>Name</dt>
+        <dd>@user.Name</dd>
+        <dt>Email</dt>
+        <dd>@user.Email</dd>
+    </dl>
+}
+
+@code {
+    private WordPressClient? client;
+    private User? user;
+    private string? jwtToken;
+    private string? error;
+
+    protected override async Task OnInitializedAsync()
+    {
+        var endpoint = await StorageJs.GetItemAsync("wpEndpoint");
+        if (string.IsNullOrEmpty(endpoint))
+        {
+            return;
+        }
+
+        var baseUrl = endpoint.TrimEnd('/') + "/wp-json/";
+        client = new WordPressClient(baseUrl);
+
+        jwtToken = await JwtService.GetCurrentJwtAsync();
+        if (!string.IsNullOrEmpty(jwtToken))
+        {
+            client.Auth.SetJWToken(jwtToken);
+        }
+
+        try
+        {
+            user = await client.Users.GetCurrentUserAsync();
+        }
+        catch (Exception ex)
+        {
+            error = ex.Message;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add user info page using WordPressPCL to fetch current user details
- link user info page in the sidebar navigation

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_68904d49b76c83229f5d4f5c3b6a98c3