### PR TITLE
Add IndexedDB demo page with conditional navigation link

### DIFF
--- a/BlazorWP.csproj
+++ b/BlazorWP.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="AntDesign" Version="1.4.1.1" />
     <PackageReference Include="TinyMCE.Blazor" Version="2.1.0" />
     <PackageReference Include="WordPressPCL" Version="2.1.0" />
+    <PackageReference Include="Tavenem.Blazor.IndexedDB" Version="6.3.4" />
   </ItemGroup>
 
 </Project>

--- a/Layout/NavMenu.razor
+++ b/Layout/NavMenu.razor
@@ -1,4 +1,6 @@
-﻿<div class="top-row ps-3 navbar navbar-dark">
+@inject AppFlags Flags
+
+<div class="top-row ps-3 navbar navbar-dark">
     <div class="container-fluid">
         <a class="navbar-brand" href="">BlazorWP</a>
         <button title="Navigation menu" class="navbar-toggler" @onclick="ToggleNavMenu">
@@ -54,6 +56,14 @@
                 <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> Data Storage
             </NavLink>
         </div>
+        @if (Flags.Mode != AppMode.Basic)
+        {
+            <div class="nav-item px-3">
+                <NavLink class="nav-link" href="indexeddb-demo">
+                    <span class="bi bi-database-fill-nav-menu" aria-hidden="true"></span> IndexedDB Demo
+                </NavLink>
+            </div>
+        }
         <div class="nav-item px-3">
             <NavLink class="nav-link" href="oauth">
                 <span class="bi bi-key-fill-nav-menu" aria-hidden="true"></span> OAuth Demo

--- a/Pages/IndexedDbDemo.razor
+++ b/Pages/IndexedDbDemo.razor
@@ -1,0 +1,122 @@
+@page "/indexeddb-demo"
+@using Microsoft.AspNetCore.Components
+@using Tavenem.Blazor.IndexedDB
+@using Tavenem.DataStore
+<PageTitle>IndexedDB Demo</PageTitle>
+
+<h3>IndexedDB Demo – Notes</h3>
+
+<!-- Note entry form (for adding or editing) -->
+<div class="mb-3">
+    <label class="form-label"><strong>Name:</strong></label>
+    <input @bind="currentNote.Name" class="form-control" placeholder="Enter note name" />
+</div>
+<div class="mb-3">
+    <label class="form-label"><strong>Description:</strong></label>
+    <textarea @bind="currentNote.Description" class="form-control" placeholder="Enter description"></textarea>
+</div>
+<button class="btn btn-primary me-2" @onclick="SaveNote">
+    @if (isEditing) { <span>Update Note</span> } else { <span>Add Note</span> }
+</button>
+@if (isEditing)
+{
+    <button class="btn btn-secondary" @onclick="CancelEdit">Cancel</button>
+}
+
+<hr />
+
+<!-- Notes list display -->
+@if (notes.Count == 0)
+{
+    <p><em>No notes available.</em></p>
+}
+else
+{
+    <table class="table align-middle">
+        <thead>
+            <tr>
+                <th>Name</th>
+                <th>Description</th>
+                <th style="width:150px;">Actions</th>
+            </tr>
+        </thead>
+        <tbody>
+        @foreach (var note in notes)
+        {
+            <tr>
+                <td>@note.Name</td>
+                <td>@note.Description</td>
+                <td>
+                    <button class="btn btn-sm btn-outline-secondary me-1" @onclick="@(() => EditNote(note))">Edit</button>
+                    <button class="btn btn-sm btn-danger" @onclick="@(() => DeleteNote(note))">Delete</button>
+                </td>
+            </tr>
+        }
+        </tbody>
+    </table>
+}
+
+@code {
+    [Inject(Key = "BlazorWPDB")] private IndexedDb NotesDb { get; set; } = default!;
+
+    private List<Note> notes = new();
+    private Note currentNote = new();
+    private bool isEditing = false;
+
+    protected override async Task OnInitializedAsync()
+    {
+        await LoadNotesAsync();
+    }
+
+    private async Task LoadNotesAsync()
+    {
+        var store = NotesDb["notes"];
+        var allNotes = await store.GetAllAsync<Note>();
+        notes = allNotes?.ToList() ?? new List<Note>();
+    }
+
+    private async Task SaveNote()
+    {
+        var store = NotesDb["notes"];
+        if (!isEditing)
+        {
+            currentNote.Id = Guid.NewGuid().ToString();
+        }
+        await store.StoreItemAsync(currentNote);
+        await LoadNotesAsync();
+        currentNote = new Note();
+        isEditing = false;
+    }
+
+    private void EditNote(Note note)
+    {
+        currentNote = new Note
+        {
+            Id = note.Id,
+            Name = note.Name,
+            Description = note.Description
+        };
+        isEditing = true;
+    }
+
+    private async Task DeleteNote(Note note)
+    {
+        var store = NotesDb["notes"];
+        await store.RemoveItemAsync(note);
+        await LoadNotesAsync();
+    }
+
+    private void CancelEdit()
+    {
+        currentNote = new Note();
+        isEditing = false;
+    }
+
+    private class Note : IIdItem
+    {
+        public string Id { get; set; } = Guid.NewGuid().ToString();
+        public string Name { get; set; } = string.Empty;
+        public string? Description { get; set; }
+    }
+}
+

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using MudBlazor.Services;
 using PanoramicData.Blazor.Extensions;
+using Tavenem.Blazor.IndexedDB;
 
 namespace BlazorWP
 {
@@ -33,6 +34,8 @@ namespace BlazorWP
             builder.Services.AddScoped<LocalStorageJsInterop>();
             builder.Services.AddScoped<SessionStorageJsInterop>();
             builder.Services.AddScoped<WpMediaJsInterop>();
+            builder.Services.AddIndexedDbService();
+            builder.Services.AddIndexedDb("BlazorWPDB", objectStores: new[] { "notes" }, version: 1);
 
             // 5) Build the host (this hooks up the logging provider)
             var host = builder.Build();


### PR DESCRIPTION
## Summary
- add Tavenem.Blazor.IndexedDB package and configure IndexedDb service
- remove duplicate AppFlags implementation and rely on existing mode flag
- implement IndexedDB CRUD demo page and show nav link only in Full mode

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b80e09d9c08322a7634be154c73b64